### PR TITLE
bunyan standard serializers

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,7 +8,8 @@ var bunyan = require('bunyan');
  */
 module.exports = bunyan.createLogger({
   name: 'ponos',
-  streams: getStreams()
+  streams: getStreams(),
+  serializers: bunyan.stdSerializers
 });
 
 // Expose get streams for unit testing


### PR DESCRIPTION
In the logs, I was seeing `err: {}` for logged errors. Turns out that bunyan needs the stdSerializers in its instance to be able to print them correctly