### PR TITLE
worker timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ options         | environment         | default
 `opts.username` | `RABBITMQ_USERNAME` | `'guest'`
 `opts.password` | `RABBITMQ_PASSWORD` | `'guest'`
 
+Other options for Ponos are as follows:
+
+Environment              | default | description
+-------------------------|---------|------------
+`WORKER_MAX_RETRY_DELAY` | `0`     | The maximum time, in milliseconds, that the worker will wait before retrying a task. The timeout will exponentially increase from `MIN_RETRY_DELAY` to `MAX_RETRY_DELAY` if the latter is set higher than the former. If this value is not set, the worker will not exponentially back off.
+`WORKER_MIN_RETRY_DELAY` | `1`     | Time, in milliseconds, the worker will wait at minimum will wait before retrying a task.
+`WORKER_TIMEOUT`         | `0`     | Timeout, in milliseconds, at which the worker task will be retried.
+
+
 ## Usage
 
 From a high level, Ponos is used to create a worker server that responds to jobs provided from RabbitMQ. The user defines handlers for each queue's jobs that are invoked by Ponos.

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -54,7 +54,7 @@ function Worker (opts) {
     runNow: true,
     // other options
     attempt: 0,
-    msTimeout: (process.env.WORKER_TIMEOUT || 3600) * 1000,
+    msTimeout: (process.env.WORKER_TIMEOUT || 0) * 1000,
     retryDelay: process.env.WORKER_MIN_RETRY_DELAY || 1
   });
 
@@ -97,13 +97,16 @@ Worker.prototype.run = function () {
         timeout: this.msTimeout
       };
       log.info(merge(jobAndQueueData, attemptData), 'Running task');
-      return Promise.resolve().bind(this)
+      var taskPromise = Promise.resolve().bind(this)
         .then(function () {
           return Promise.resolve().bind(this)
             .cancellable()
             .then(function () { return this.task(this.job); });
-        })
-        .timeout(this.msTimeout);
+        });
+      if (this.msTimeout) {
+        taskPromise = taskPromise.timeout(this.msTimeout);
+      }
+      return taskPromise;
     })
     .then(function successDone (result) {
       log.info(merge(jobAndQueueData, { result: result }), 'Task complete');

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -2,12 +2,13 @@
 
 var Promise = require('bluebird');
 var TaskFatalError = require('./errors/task-fatal-error');
+var TimeoutError = Promise.TimeoutError;
 var assign = require('101/assign');
-var merge = require('101/put');
 var defaults = require('101/defaults');
 var error = require('./error');
 var exists = require('101/exists');
 var log = require('./logger').child({ module: 'worker' });
+var merge = require('101/put');
 var pick = require('101/pick');
 
 /**
@@ -53,6 +54,7 @@ function Worker (opts) {
     runNow: true,
     // other options
     attempt: 0,
+    msTimeout: (process.env.WORKER_TIMEOUT || 3600) * 1000,
     retryDelay: process.env.WORKER_MIN_RETRY_DELAY || 1
   });
 
@@ -90,13 +92,28 @@ Worker.prototype.run = function () {
   };
   return Promise.resolve().bind(this)
     .then(function runTheTask () {
-      var attemptData = { attempt: this.attempt++ };
+      var attemptData = {
+        attempt: this.attempt++,
+        timeout: this.msTimeout
+      };
       log.info(merge(jobAndQueueData, attemptData), 'Running task');
-      return this.task(this.job);
+      return Promise.resolve().bind(this)
+        .then(function () {
+          return Promise.resolve().bind(this)
+            .cancellable()
+            .then(function () { return this.task(this.job); });
+        })
+        .timeout(this.msTimeout);
     })
     .then(function successDone (result) {
       log.info(merge(jobAndQueueData, { result: result }), 'Task complete');
       return this.done();
+    })
+    // if the type is TimeoutError, we will log and retry
+    .catch(TimeoutError, function timeoutErrRetry (err) {
+      log.warn(merge(jobAndQueueData, { err: err }), 'Task timed out');
+      // just by throwing this type of error, we will retry :)
+      throw err;
     })
     // if it's a known type of error, we can't accomplish the task
     .catch(TaskFatalError, function knownErrDone (err) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -54,7 +54,7 @@ function Worker (opts) {
     runNow: true,
     // other options
     attempt: 0,
-    msTimeout: (process.env.WORKER_TIMEOUT || 0) * 1000,
+    msTimeout: process.env.WORKER_TIMEOUT || 0,
     retryDelay: process.env.WORKER_MIN_RETRY_DELAY || 1
   });
 

--- a/test/functional/fixtures/timeout-worker.js
+++ b/test/functional/fixtures/timeout-worker.js
@@ -8,7 +8,8 @@ var TaskFatalError = ponos.TaskFatalError;
 
 /**
  * A worker that will publish a message to an event emitter. This worker also
- * will take a long time to do so (causing timeouts).
+ * will take a long time to do so (causing timeouts). It has a _timeout value
+ * below that is halved every run to provide a hastening task.
  * @param {object} job Object describing the job.
  * @param {string} job.queue Queue on which the message will be published.
  * @returns {promise} Resolved when the message is put on the queue.
@@ -20,8 +21,9 @@ module.exports = function (job) {
       if (!job.message) { throw new TaskFatalError('message is required'); }
     })
     .then(function () {
-      var timeout = module.exports.globalTimeout;
-      module.exports.globalTimeout = module.exports.globalTimeout / 2;
+      var timeout = module.exports._timeout;
+      // every time this worker is run, it will halve it's delay (run) time
+      module.exports._timeout = module.exports._timeout / 2;
       return Promise.resolve()
         .delay(timeout)
         .then(function () {
@@ -31,5 +33,6 @@ module.exports = function (job) {
     });
 };
 
-module.exports.globalTimeout = 3000;
+// this _timeout value is the starting value for how long this worker will take
+module.exports._timeout = 3000;
 module.exports.emitter = new EventEmitter();

--- a/test/functional/fixtures/timeout-worker.js
+++ b/test/functional/fixtures/timeout-worker.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+var ponos = require('../../../');
+var Promise = require('bluebird');
+
+var TaskFatalError = ponos.TaskFatalError;
+
+/**
+ * A worker that will publish a message to an event emitter. This worker also
+ * will take a long time to do so (causing timeouts).
+ * @param {object} job Object describing the job.
+ * @param {string} job.queue Queue on which the message will be published.
+ * @returns {promise} Resolved when the message is put on the queue.
+ */
+module.exports = function (job) {
+  return Promise.resolve()
+    .then(function () {
+      if (!job.eventName) { throw new TaskFatalError('eventName is required'); }
+      if (!job.message) { throw new TaskFatalError('message is required'); }
+    })
+    .then(function () {
+      var timeout = module.exports.globalTimeout;
+      module.exports.globalTimeout = module.exports.globalTimeout / 2;
+      return Promise.resolve()
+        .delay(timeout)
+        .then(function () {
+          module.exports.emitter.emit(job.eventName, { data: job.message });
+          return true;
+        });
+    });
+};
+
+module.exports.globalTimeout = 3000;
+module.exports.emitter = new EventEmitter();

--- a/test/functional/timeout.js
+++ b/test/functional/timeout.js
@@ -56,7 +56,7 @@ describe('Basic Timeout Task', function () {
     var prevTimeout;
     before(function () {
       prevTimeout = process.env.WORKER_TIMEOUT;
-      process.env.WORKER_TIMEOUT = 1;
+      process.env.WORKER_TIMEOUT = 1000;
     });
     after(function () { process.env.WORKER_TIMEOUT = prevTimeout; });
 

--- a/test/functional/timeout.js
+++ b/test/functional/timeout.js
@@ -1,0 +1,95 @@
+'use strict';
+
+var chai = require('chai');
+chai.use(require('chai-as-promised'));
+var assert = chai.assert;
+var sinon = require('sinon');
+
+// Ponos Tooling
+var ponos = require('../../');
+var TimeoutError = require('bluebird').TimeoutError;
+var testWorker = require('./fixtures/timeout-worker');
+var testWorkerEmitter = testWorker.emitter;
+
+// require the Worker class so we can verify the task is running
+var _Worker = require('../../lib/worker');
+// require the error module so we can see the error printed
+var _Bunyan = require('bunyan');
+
+/*
+ *  In this example, we are going to have a job handler that times out at
+ *  decreasing intervals, throwing TimeoutErrors, until it passes.
+ */
+describe('Basic Timeout Task', function () {
+  this.timeout(3500);
+  var server;
+  var prevTimeout;
+  before(function (done) {
+    prevTimeout = process.env.WORKER_TIMEOUT;
+    process.env.WORKER_TIMEOUT = 1;
+    sinon.spy(_Worker.prototype, 'run');
+    sinon.spy(_Bunyan.prototype, 'warn');
+    var tasks = {
+      'ponos-test:one': testWorker
+    };
+    server = new ponos.Server({ queues: Object.keys(tasks) });
+    server.setAllTasks(tasks)
+      .then(server.start())
+      .then(function () {
+        assert.notOk(_Worker.prototype.run.called, '.run should not be called');
+        done();
+      })
+      .catch(done);
+  });
+  after(function (done) {
+    server.stop()
+      .then(function () {
+        process.env.WORKER_TIMEOUT = prevTimeout;
+        _Worker.prototype.run.restore();
+        _Bunyan.prototype.warn.restore();
+        done();
+      });
+  });
+
+  var job = {
+    eventName: 'did-not-time-out',
+    message: 'hello world'
+  };
+
+  it('should fail twice and pass the third time', function (done) {
+    testWorkerEmitter.on('did-not-time-out', function () {
+      // setTimeout so the worker can resolve
+      setTimeout(function () {
+        // this signals to us that we are done!
+        assert.ok(_Worker.prototype.run.calledThrice, '.run called thrice');
+        /*
+         *  We can get the promise and assure that it was fulfilled!
+         *  It was run three times and all three should be fulfilled.
+         */
+        [
+          _Worker.prototype.run.firstCall.returnValue,
+          _Worker.prototype.run.secondCall.returnValue,
+          _Worker.prototype.run.thirdCall.returnValue
+        ].forEach(function (p) { assert.isFulfilled(p); });
+        // and, make sure the error module has logged the TimeoutError twice
+        // have to do a bit of weird filtering, but this is correct. Long story
+        // short, log.warn is called a couple times, but we just want to make
+        // sure the 'task timed out' message is just twice (the number of times
+        // this worker failed).
+        var errors = _Bunyan.prototype.warn.args.reduce(function (memo, args) {
+          var checkArgs = args.filter(function (arg) {
+            return /task timed out/i.test(arg);
+          });
+          if (checkArgs.length) { memo.push(args.shift().err); }
+          return memo;
+        }, []);
+        errors.forEach(function (err) {
+          assert.instanceOf(err, TimeoutError);
+        });
+        done();
+      }, 50);
+    });
+
+    server.hermes.publish('ponos-test:one', job);
+  });
+});

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -5,9 +5,10 @@ chai.use(require('chai-as-promised'));
 var assert = chai.assert;
 var sinon = require('sinon');
 
+var Promise = require('bluebird');
 var TaskError = require('../../lib/errors/task-error');
 var TaskFatalError = require('../../lib/errors/task-fatal-error');
-var Promise = require('bluebird');
+var TimeoutError = Promise.TimeoutError;
 var Worker = require('../../lib/worker');
 var assign = require('101/assign');
 var error = require('../../lib/error');
@@ -132,6 +133,16 @@ describe('Worker', function () {
       it('should retry if task throws TaskError', function () {
         taskHandler = sinon.stub();
         taskHandler.onFirstCall().throws(new TaskError('foobar'));
+        doneHandler = sinon.stub();
+        return assert.isFulfilled(worker.run())
+          .then(function () {
+            assert.equal(taskHandler.callCount, 2, 'task was called twice');
+            assert.ok(doneHandler.calledOnce, 'done was called once');
+          });
+      });
+      it('should retry if task throws TimeoutError', function () {
+        taskHandler = sinon.stub();
+        taskHandler.onFirstCall().throws(new TimeoutError());
         doneHandler = sinon.stub();
         return assert.isFulfilled(worker.run())
           .then(function () {

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -46,9 +46,9 @@ describe('Worker', function () {
       Worker.create(testOpts);
       assert.notOk(Worker.prototype.run.calledOnce, '.run not called');
     });
-    it('should default the timeout to an hour', function () {
+    it('should default the timeout to not exist', function () {
       var w = Worker.create(opts);
-      assert.equal(w.msTimeout, 60 * 60 * 1000, 'set the timeout correctly');
+      assert.equal(w.msTimeout, 0, 'set the timeout correctly');
     });
     describe('with worker timeout', function () {
       var prevTimeout;
@@ -57,6 +57,7 @@ describe('Worker', function () {
         process.env.WORKER_TIMEOUT = 4;
       });
       after(function () { process.env.WORKER_MAX_RETRY_DELAY = prevTimeout; });
+
       it('should use the environment timeout', function () {
         var w = Worker.create(opts);
         assert.equal(w.msTimeout, 4 * 1000, 'set the timeout correctly');

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -56,7 +56,7 @@ describe('Worker', function () {
         prevTimeout = process.env.WORKER_TIMEOUT;
         process.env.WORKER_TIMEOUT = 4;
       });
-      after(function () { process.env.WORKER_MAX_RETRY_DELAY = prevTimeout; });
+      after(function () { process.env.WORKER_TIMEOUT = prevTimeout; });
 
       it('should use the environment timeout', function () {
         var w = Worker.create(opts);

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -85,6 +85,30 @@ describe('Worker', function () {
           });
       });
 
+      describe('with worker timeout', function () {
+        var prevTimeout;
+        before(function () {
+          prevTimeout = process.env.WORKER_TIMEOUT;
+          process.env.WORKER_TIMEOUT = 0.01;
+        });
+        after(function () { process.env.WORKER_TIMEOUT = prevTimeout; });
+
+        it('should timeout the job', function () {
+          // we are going to replace the handler w/ a stub
+          taskHandler = function () {
+            taskHandler = sinon.stub();
+            return Promise.resolve().delay(25);
+          };
+          doneHandler = sinon.stub();
+          return assert.isFulfilled(worker.run())
+            .then(function () {
+              // this is asserting taskHandler called once, but was twice
+              assert.ok(taskHandler.calledOnce, 'task was called once');
+              assert.ok(doneHandler.calledOnce, 'done was called once');
+            });
+        });
+      });
+
       describe('with max retry delay', function () {
         var prevDelay;
         before(function () {

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -45,6 +45,22 @@ describe('Worker', function () {
       Worker.create(testOpts);
       assert.notOk(Worker.prototype.run.calledOnce, '.run not called');
     });
+    it('should default the timeout to an hour', function () {
+      var w = Worker.create(opts);
+      assert.equal(w.msTimeout, 60 * 60 * 1000, 'set the timeout correctly');
+    });
+    describe('with worker timeout', function () {
+      var prevTimeout;
+      before(function () {
+        prevTimeout = process.env.WORKER_TIMEOUT;
+        process.env.WORKER_TIMEOUT = 4;
+      });
+      after(function () { process.env.WORKER_MAX_RETRY_DELAY = prevTimeout; });
+      it('should use the environment timeout', function () {
+        var w = Worker.create(opts);
+        assert.equal(w.msTimeout, 4 * 1000, 'set the timeout correctly');
+      });
+    });
   });
 
   describe('run', function () {

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -54,7 +54,7 @@ describe('Worker', function () {
       var prevTimeout;
       before(function () {
         prevTimeout = process.env.WORKER_TIMEOUT;
-        process.env.WORKER_TIMEOUT = 4;
+        process.env.WORKER_TIMEOUT = 4000;
       });
       after(function () { process.env.WORKER_TIMEOUT = prevTimeout; });
 
@@ -89,7 +89,7 @@ describe('Worker', function () {
         var prevTimeout;
         before(function () {
           prevTimeout = process.env.WORKER_TIMEOUT;
-          process.env.WORKER_TIMEOUT = 0.01;
+          process.env.WORKER_TIMEOUT = 10;
         });
         after(function () { process.env.WORKER_TIMEOUT = prevTimeout; });
 


### PR DESCRIPTION
Now workers can be set to time out! Pretty cool, eh!? Unit and functional tests have been created for this functionality.

~~One interesting corner is that setting the timeout to 0 does not actually give the worker infinite time (it will fail almost immediately). Is this good? Is that what we want to do? I might be able to have the timeout added conditionally, but I just want to pose the question.~~

Edit: I think the `0` timeout thing has been resolved. See discussion below.