### PR TITLE
Replace throw with warn log

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -213,9 +213,10 @@ Server.prototype.setAllTasks = function (map) {
     var value = map[key]
     if (isObject(value)) {
       if (!isFunction(value.task)) {
-        this.log.warn({
+        log.warn({
           key: key
         }, 'ponos.Server.setAllTasks: No task function defined')
+        return this
       }
       this.setTask(key, value.task, value)
     } else {
@@ -236,9 +237,7 @@ Server.prototype.setTask = function (queueName, task, opts) {
   debug('setTask(' + [ queueName, task ].join(', ') + ')')
   this.log.trace('ponos.Server: setting task for ' + queueName)
   if (!isFunction(task)) {
-    throw new Error(
-      'ponos.Server.setTask: Provided task handler is not a function'
-    )
+    throw new Error('ponos.Server.setTask: Provided task handler is not a function')
   }
   this._tasks[queueName] = task
   this._workerOptions[queueName] = isObject(opts)

--- a/lib/server.js
+++ b/lib/server.js
@@ -216,7 +216,7 @@ Server.prototype.setAllTasks = function (map) {
         log.warn({
           key: key
         }, 'ponos.Server.setAllTasks: No task function defined')
-        return this
+        return
       }
       this.setTask(key, value.task, value)
     } else {

--- a/lib/server.js
+++ b/lib/server.js
@@ -213,9 +213,9 @@ Server.prototype.setAllTasks = function (map) {
     var value = map[key]
     if (isObject(value)) {
       if (!isFunction(value.task)) {
-        throw new Error(
-          'ponos.Server.setAllTasks: No task function defined for ' + key
-        )
+        this.log.warn({
+          key: key
+        }, 'ponos.Server.setAllTasks: No task function defined')
       }
       this.setTask(key, value.task, value)
     } else {

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -400,8 +400,7 @@ describe('Server', function () {
         sinon.assert.calledOnce(server.log.warn)
         sinon.assert.calledWith(server.log.warn,
           sinon.match.object, 'ponos.Server.setAllTasks: No task function defined')
-        sinon.assert.calledOnce(server.setTask)
-        sinon.assert.calledWith(server.setTask, queue, undefined, tasks[queue])
+        sinon.assert.notCalled(server.setTask)
       })
 
       it('should pass options when calling setTask', function () {

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -371,24 +371,34 @@ describe('Server', function () {
     var queue = Object.keys(tasks)[0]
 
     beforeEach(function () {
-      sinon.spy(server, 'setTask')
+      sinon.stub(server, 'setTask')
+    })
+
+    afterEach(function () {
+      server.setTask.restore()
     })
 
     it('should set multiple tasks', function () {
       var numTasks = Object.keys(tasks).length
       server.setAllTasks(tasks)
-      assert.equal(server.setTask.callCount, numTasks)
-      assert.equal(Object.keys(server._tasks).length, numTasks)
+      sinon.assert.callCount(server.setTask, numTasks)
     })
 
     describe('with option objects', function () {
+      beforeEach(function () {
+        sinon.stub(server.log, 'warn')
+      })
+
+      afterEach(function () {
+        server.log.warn.restore()
+      })
+
       it('should throw if a task is not defined', function () {
         var tasks = {}
         tasks[queue] = { msTimeout: 2000 }
-        assert.throws(function () {
-          server.setAllTasks(tasks)
-        }, /No task function defined/)
-        assert.equal(server.setTask.callCount, 0)
+        server.setAllTasks(tasks)
+        sinon.assert.calledOnce(server.log.warn)
+        sinon.assert.calledOnce(server.setTask)
       })
 
       it('should pass options when calling setTask', function () {

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -398,8 +398,11 @@ describe('Server', function () {
         tasks[queue] = { msTimeout: 2000 }
         server.setAllTasks(tasks)
         sinon.assert.calledOnce(server.log.warn)
-        sinon.assert.calledWith(server.log.warn,
-          sinon.match.object, 'ponos.Server.setAllTasks: No task function defined')
+        sinon.assert.calledWith(
+          server.log.warn,
+          sinon.match.object,
+          'ponos.Server.setAllTasks: No task function defined'
+        )
         sinon.assert.notCalled(server.setTask)
       })
 

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -398,7 +398,10 @@ describe('Server', function () {
         tasks[queue] = { msTimeout: 2000 }
         server.setAllTasks(tasks)
         sinon.assert.calledOnce(server.log.warn)
+        sinon.assert.calledWith(server.log.warn,
+          sinon.match.object, 'ponos.Server.setAllTasks: No task function defined')
         sinon.assert.calledOnce(server.setTask)
+        sinon.assert.calledWith(server.setTask, queue, undefined, tasks[queue])
       })
 
       it('should pass options when calling setTask', function () {

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -400,7 +400,7 @@ describe('Server', function () {
         sinon.assert.calledOnce(server.log.warn)
         sinon.assert.calledWith(
           server.log.warn,
-          sinon.match.object,
+          sinon.match.has('key', queue),
           'ponos.Server.setAllTasks: No task function defined'
         )
         sinon.assert.notCalled(server.setTask)

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -393,7 +393,7 @@ describe('Server', function () {
         server.log.warn.restore()
       })
 
-      it('should throw if a task is not defined', function () {
+      it('should log a warning if a task is not defined', function () {
         var tasks = {}
         tasks[queue] = { msTimeout: 2000 }
         server.setAllTasks(tasks)


### PR DESCRIPTION
Ponos currently throws an error if not all queues listed in hermes have associated workers.
This PR replaces the throw with a warn log.