### PR TITLE
Add monitor-dog

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -153,7 +153,7 @@ Worker.prototype.run = function () {
     job: this.job
   }
   this._inc('ponos')
-  var timer = monitor.timer('ponos.timer', this._eventTags())
+  var timer = monitor.timer('ponos.timer', !process.env.WORKER_MONITOR_DISABLED, this._eventTags())
   return Promise.resolve().bind(this)
     .then(function runTheTask () {
       var attemptData = {
@@ -218,9 +218,6 @@ Worker.prototype.run = function () {
         })
     })
     .finally(function () {
-      if (process.env.WORKER_MONITOR_DISABLED) {
-        return
-      }
       timer.stop()
     })
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -153,9 +153,7 @@ Worker.prototype.run = function () {
     job: this.job
   }
   this._inc('ponos')
-  if (process.env.WORKER_MONITOR) {
-    var timer = monitor.timer('ponos.timer', this._eventTags())
-  }
+  var timer = monitor.timer('ponos.timer', this._eventTags())
   return Promise.resolve().bind(this)
     .then(function runTheTask () {
       var attemptData = {
@@ -220,8 +218,9 @@ Worker.prototype.run = function () {
         })
     })
     .finally(function () {
-      if (process.env.WORKER_MONITOR) {
-        timer.stop()
+      if (process.env.WORKER_MONITOR_DISABLED) {
+        return
       }
+      timer.stop()
     })
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -111,6 +111,20 @@ Worker.prototype._reportError = function (err) {
   this.errorCat.report(err)
 }
 
+Worker.prototype._eventTags = function () {
+  var tokens = this.queue.split('.').reverse()
+  var lastToken = ''
+  var tags = tokens.reduce(function (acc, currentValue, currentIndex) {
+    var key = 'token-' + currentIndex
+    var newToken = (currentIndex === 0 ? currentValue : currentValue + '.' + lastToken)
+    acc[key] = newToken
+    lastToken = newToken
+    return acc
+  }, {})
+  tags.queue = this.queue
+  return tags
+}
+
 /**
  * Runs the worker. If the task for the job fails, then this method will retry
  * the task (with an exponential backoff) a number of times defined by the
@@ -123,8 +137,8 @@ Worker.prototype.run = function () {
     job: this.job
   }
   if (process.env.WORKER_MONITOR) {
-    monitor.increment('ponos.' + this.queue)
-    var timer = monitor.timer('ponos.' + this.queue + '.time')
+    monitor.increment('ponos', this._eventTags())
+    var timer = monitor.timer('ponos.timer', this._eventTags())
   }
   return Promise.resolve().bind(this)
     .then(function runTheTask () {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -130,6 +130,17 @@ Worker.prototype._eventTags = function () {
   return tags
 }
 
+Worker.prototype._inc = function (type, result) {
+  if (process.env.WORKER_MONITOR_DISABLED) {
+    return
+  }
+  var tags = this._eventTags()
+  if (result) {
+    tags.result = result
+  }
+  monitor.increment(type, tags)
+}
+
 /**
  * Runs the worker. If the task for the job fails, then this method will retry
  * the task (with an exponential backoff) a number of times defined by the
@@ -141,8 +152,8 @@ Worker.prototype.run = function () {
     queue: this.queue,
     job: this.job
   }
+  this._inc('ponos')
   if (process.env.WORKER_MONITOR) {
-    monitor.increment('ponos', this._eventTags())
     var timer = monitor.timer('ponos.timer', this._eventTags())
   }
   return Promise.resolve().bind(this)
@@ -167,32 +178,20 @@ Worker.prototype.run = function () {
         merge(jobAndQueueData, { result: result }),
         'Task complete'
       )
-      if (process.env.WORKER_MONITOR) {
-        var tags = this._eventTags()
-        tags.result = 'success'
-        monitor.increment('ponos.finish', tags)
-      }
+      this._inc('ponos.finish', 'success')
       return this.done()
     })
     // if the type is TimeoutError, we will log and retry
     .catch(TimeoutError, function timeoutErrRetry (err) {
       log.warn(merge(jobAndQueueData, { err: err }), 'Task timed out')
-      if (process.env.WORKER_MONITOR) {
-        var tags = this._eventTags()
-        tags.result = 'timeout-error'
-        monitor.increment('ponos.finish', tags)
-      }
+      this._inc('ponos.finish', 'timeout-error')
       // just by throwing this type of error, we will retry :)
       throw err
     })
     // if it's a known type of error, we can't accomplish the task
     .catch(TaskFatalError, function knownErrDone (err) {
       this.log.error({ err: err }, 'Worker task fatally errored')
-      if (process.env.WORKER_MONITOR) {
-        var tags = this._eventTags()
-        tags.result = 'fatal-error'
-        monitor.increment('ponos.finish', tags)
-      }
+      this._inc('ponos.finish', 'fatal-error')
       this._reportError(err)
       // If we encounter a fatal error we should no longer try to schedule
       // the job.
@@ -207,11 +206,7 @@ Worker.prototype.run = function () {
         merge(jobAndQueueData, attemptData),
         'Task failed, retrying'
       )
-      if (process.env.WORKER_MONITOR) {
-        var tags = this._eventTags()
-        tags.result = 'task-error'
-        monitor.increment('ponos.finish', tags)
-      }
+      this._inc('ponos.finish', 'task-error')
       this._reportError(err)
 
       // Try again after a delay

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -120,7 +120,7 @@ Worker.prototype._eventTags = function () {
   var tokens = this.queue.split('.').reverse()
   var lastToken = ''
   var tags = tokens.reduce(function (acc, currentValue, currentIndex) {
-    var key = 'token-' + currentIndex
+    var key = 'token' + currentIndex
     var newToken = (currentIndex === 0 ? currentValue : currentValue + '.' + lastToken)
     acc[key] = newToken
     lastToken = newToken

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -111,6 +111,11 @@ Worker.prototype._reportError = function (err) {
   this.errorCat.report(err)
 }
 
+/**
+ * Helper function for creating monitor-dog events tags
+ * @private
+ * @param {Object} tags as Object {queue: 'docker.event.publish'}
+ */
 Worker.prototype._eventTags = function () {
   var tokens = this.queue.split('.').reverse()
   var lastToken = ''

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -167,17 +167,32 @@ Worker.prototype.run = function () {
         merge(jobAndQueueData, { result: result }),
         'Task complete'
       )
+      if (process.env.WORKER_MONITOR) {
+        var tags = this._eventTags()
+        tags.result = 'success'
+        monitor.increment('ponos.finish', tags)
+      }
       return this.done()
     })
     // if the type is TimeoutError, we will log and retry
     .catch(TimeoutError, function timeoutErrRetry (err) {
       log.warn(merge(jobAndQueueData, { err: err }), 'Task timed out')
+      if (process.env.WORKER_MONITOR) {
+        var tags = this._eventTags()
+        tags.result = 'timeout-error'
+        monitor.increment('ponos.finish', tags)
+      }
       // just by throwing this type of error, we will retry :)
       throw err
     })
     // if it's a known type of error, we can't accomplish the task
     .catch(TaskFatalError, function knownErrDone (err) {
       this.log.error({ err: err }, 'Worker task fatally errored')
+      if (process.env.WORKER_MONITOR) {
+        var tags = this._eventTags()
+        tags.result = 'fatal-error'
+        monitor.increment('ponos.finish', tags)
+      }
       this._reportError(err)
       // If we encounter a fatal error we should no longer try to schedule
       // the job.
@@ -192,6 +207,11 @@ Worker.prototype.run = function () {
         merge(jobAndQueueData, attemptData),
         'Task failed, retrying'
       )
+      if (process.env.WORKER_MONITOR) {
+        var tags = this._eventTags()
+        tags.result = 'task-error'
+        monitor.increment('ponos.finish', tags)
+      }
       this._reportError(err)
 
       // Try again after a delay

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -157,6 +157,19 @@ Worker.prototype._incMonitor = function (eventName, extraTags) {
 }
 
 /**
+ * Helper function calling `monitor.timer`.
+ * Timer wouldn't be created if `process.env.WORKER_MONITOR_DISABLED` set
+ * @return {object} new timer
+ * @private
+ */
+Worker.prototype._createTimer = function () {
+  var tags = this._eventTags()
+  return !process.env.WORKER_MONITOR_DISABLED
+    ? monitor.timer('ponos.timer', true, tags)
+    : null
+}
+
+/**
  * Runs the worker. If the task for the job fails, then this method will retry
  * the task (with an exponential backoff) a number of times defined by the
  * environment of the process.
@@ -168,7 +181,7 @@ Worker.prototype.run = function () {
     job: this.job
   }
   this._incMonitor('ponos')
-  var timer = monitor.timer('ponos.timer', !process.env.WORKER_MONITOR_DISABLED, this._eventTags())
+  var timer = this._createTimer()
   return Promise.resolve().bind(this)
     .then(function runTheTask () {
       var attemptData = {
@@ -233,6 +246,8 @@ Worker.prototype.run = function () {
         })
     })
     .finally(function () {
-      timer.stop()
+      if (timer) {
+        timer.stop()
+      }
     })
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -113,8 +113,16 @@ Worker.prototype._reportError = function (err) {
 
 /**
  * Helper function for creating monitor-dog events tags
+ * `queue` is the only mandatory tag.
+ * Few tags would be created depednding on the queue name
+ * If queueName use `.` as delimiter e.x. `10.0.0.20.api.github.push` then
+ * following tags would be created:
+ * - token0: 'push'
+ * - token1: 'github.push'
+ * - token2: 'api.github.push'
+ * - token3: '10.0.0.20.api.github.push'
  * @private
- * @param {Object} tags as Object {queue: 'docker.event.publish'}
+ * @returns {Object} tags as Object {queue: 'docker.event.publish'}
  */
 Worker.prototype._eventTags = function () {
   var tokens = this.queue.split('.').reverse()
@@ -130,6 +138,13 @@ Worker.prototype._eventTags = function () {
   return tags
 }
 
+/**
+ * Helper function calling `monitor.increment`.
+ * Monitor wouldn't be called if `process.env.WORKER_MONITOR_DISABLED` set.
+ * @param {string} eventName name to be reported into the datadog
+ * @param {object} [extraTags] extra tags to be send with the event
+ * @private
+ */
 Worker.prototype._inc = function (eventName, extraTags) {
   if (process.env.WORKER_MONITOR_DISABLED) {
     return

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -6,6 +6,7 @@ var TimeoutError = Promise.TimeoutError
 var assign = require('101/assign')
 var defaults = require('101/defaults')
 var ErrorCat = require('error-cat')
+var monitor = require('monitor-dog')
 var exists = require('101/exists')
 var isNumber = require('101/is-number')
 var isObject = require('101/is-object')
@@ -121,6 +122,10 @@ Worker.prototype.run = function () {
     queue: this.queue,
     job: this.job
   }
+  if (process.env.WORKER_MONITOR) {
+    monitor.increment('ponos.' + this.queue)
+    var timer = monitor.timer('ponos.' + this.queue + '.time')
+  }
   return Promise.resolve().bind(this)
     .then(function runTheTask () {
       var attemptData = {
@@ -179,5 +184,10 @@ Worker.prototype.run = function () {
           }
           return this.run()
         })
+    })
+    .finally(function () {
+      if (process.env.WORKER_MONITOR) {
+        timer.stop()
+      }
     })
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -130,15 +130,15 @@ Worker.prototype._eventTags = function () {
   return tags
 }
 
-Worker.prototype._inc = function (type, result) {
+Worker.prototype._inc = function (eventName, extraTags) {
   if (process.env.WORKER_MONITOR_DISABLED) {
     return
   }
   var tags = this._eventTags()
-  if (result) {
-    tags.result = result
+  if (extraTags) {
+    tags = merge(tags, extraTags)
   }
-  monitor.increment(type, tags)
+  monitor.increment(eventName, tags)
 }
 
 /**
@@ -176,20 +176,20 @@ Worker.prototype.run = function () {
         merge(jobAndQueueData, { result: result }),
         'Task complete'
       )
-      this._inc('ponos.finish', 'success')
+      this._inc('ponos.finish', { result: 'success' })
       return this.done()
     })
     // if the type is TimeoutError, we will log and retry
     .catch(TimeoutError, function timeoutErrRetry (err) {
       log.warn(merge(jobAndQueueData, { err: err }), 'Task timed out')
-      this._inc('ponos.finish', 'timeout-error')
+      this._inc('ponos.finish', { result: 'timeout-error' })
       // just by throwing this type of error, we will retry :)
       throw err
     })
     // if it's a known type of error, we can't accomplish the task
     .catch(TaskFatalError, function knownErrDone (err) {
       this.log.error({ err: err }, 'Worker task fatally errored')
-      this._inc('ponos.finish', 'fatal-error')
+      this._inc('ponos.finish', { result: 'fatal-error' })
       this._reportError(err)
       // If we encounter a fatal error we should no longer try to schedule
       // the job.
@@ -204,7 +204,7 @@ Worker.prototype.run = function () {
         merge(jobAndQueueData, attemptData),
         'Task failed, retrying'
       )
-      this._inc('ponos.finish', 'task-error')
+      this._inc('ponos.finish', { result: 'task-error' })
       this._reportError(err)
 
       // Try again after a delay

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -114,7 +114,7 @@ Worker.prototype._reportError = function (err) {
 /**
  * Helper function for creating monitor-dog events tags
  * `queue` is the only mandatory tag.
- * Few tags would be created depednding on the queue name
+ * Few tags would be created depending on the queue name
  * If queueName use `.` as delimiter e.x. `10.0.0.20.api.github.push` then
  * following tags would be created:
  * - token0: 'push'
@@ -145,7 +145,7 @@ Worker.prototype._eventTags = function () {
  * @param {object} [extraTags] extra tags to be send with the event
  * @private
  */
-Worker.prototype._inc = function (eventName, extraTags) {
+Worker.prototype._incMonitor = function (eventName, extraTags) {
   if (process.env.WORKER_MONITOR_DISABLED) {
     return
   }
@@ -167,7 +167,7 @@ Worker.prototype.run = function () {
     queue: this.queue,
     job: this.job
   }
-  this._inc('ponos')
+  this._incMonitor('ponos')
   var timer = monitor.timer('ponos.timer', !process.env.WORKER_MONITOR_DISABLED, this._eventTags())
   return Promise.resolve().bind(this)
     .then(function runTheTask () {
@@ -191,20 +191,20 @@ Worker.prototype.run = function () {
         merge(jobAndQueueData, { result: result }),
         'Task complete'
       )
-      this._inc('ponos.finish', { result: 'success' })
+      this._incMonitor('ponos.finish', { result: 'success' })
       return this.done()
     })
     // if the type is TimeoutError, we will log and retry
     .catch(TimeoutError, function timeoutErrRetry (err) {
       log.warn(merge(jobAndQueueData, { err: err }), 'Task timed out')
-      this._inc('ponos.finish', { result: 'timeout-error' })
+      this._incMonitor('ponos.finish', { result: 'timeout-error' })
       // just by throwing this type of error, we will retry :)
       throw err
     })
     // if it's a known type of error, we can't accomplish the task
     .catch(TaskFatalError, function knownErrDone (err) {
       this.log.error({ err: err }, 'Worker task fatally errored')
-      this._inc('ponos.finish', { result: 'fatal-error' })
+      this._incMonitor('ponos.finish', { result: 'fatal-error' })
       this._reportError(err)
       // If we encounter a fatal error we should no longer try to schedule
       // the job.
@@ -219,7 +219,7 @@ Worker.prototype.run = function () {
         merge(jobAndQueueData, attemptData),
         'Task failed, retrying'
       )
-      this._inc('ponos.finish', { result: 'task-error' })
+      this._incMonitor('ponos.finish', { result: 'task-error' })
       this._reportError(err)
 
       // Try again after a delay

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bunyan": "^1.5.1",
     "debug": "^2.2.0",
     "error-cat": "^1.3.4",
-    "monitor-dog": "git://github.com/Runnable/monitor-dog.git#pass-tags-to-timer",
+    "monitor-dog": "1.5.0",
     "runnable-hermes": "^6.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "bunyan": "^1.5.1",
     "debug": "^2.2.0",
     "error-cat": "^1.3.4",
+    "monitor-dog": "^1.4.1",
     "runnable-hermes": "^6.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bunyan": "^1.5.1",
     "debug": "^2.2.0",
     "error-cat": "^1.3.4",
-    "monitor-dog": "^1.4.1",
+    "monitor-dog": "git://github.com/Runnable/ponos.git#pass-tags-to-timer",
     "runnable-hermes": "^6.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "bunyan": "^1.5.1",
     "debug": "^2.2.0",
     "error-cat": "^1.3.4",
-    "monitor-dog": "git://github.com/Runnable/ponos.git#pass-tags-to-timer",
+    "monitor-dog": "git://github.com/Runnable/monitor-dog.git#pass-tags-to-timer",
     "runnable-hermes": "^6.4.0"
   },
   "devDependencies": {

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -292,7 +292,7 @@ describe('Worker', function () {
             sinon.assert.calledOnce(timer.stop)
           })
       })
-      
+
       describe('with disabled monitoring', function () {
         beforeEach(function () {
           process.env.WORKER_MONITOR_DISABLED = 'true'

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -20,7 +20,7 @@ describe('Worker', function () {
 
   beforeEach(function () {
     opts = {
-      queue: 'a-queue',
+      queue: 'do.something.command',
       task: function (data) { return Promise.resolve(data).then(taskHandler) },
       job: { message: 'hello world' },
       done: function () { return Promise.resolve().then(doneHandler) }
@@ -200,7 +200,17 @@ describe('Worker', function () {
               assert.ok(taskHandler.calledOnce, 'task was called once')
               assert.ok(doneHandler.calledOnce, 'done was called once')
               assert.ok(monitor.increment.calledOnce, 'monitor.inc was called once')
+              assert.ok(monitor.increment.calledWith('ponos',
+                { 'token-0': 'command',
+                  'token-1': 'something.command',
+                  'token-2': 'do.something.command',
+                  queue: 'do.something.command' }), 'monitor.inc was called once with args')
               assert.ok(monitor.timer.calledOnce, 'monitor.timer was called once')
+              assert.ok(monitor.timer.calledWith('ponos.timer',
+                { 'token-0': 'command',
+                  'token-1': 'something.command',
+                  'token-2': 'do.something.command',
+                  queue: 'do.something.command' }), 'monitor.inc was called once with args')
               assert.ok(timer.stop.calledOnce, 'timer.stop was called once')
             })
         })

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -224,50 +224,15 @@ describe('Worker', function () {
               token2: 'do.something.command',
               queue: 'do.something.command'
             })
-            assert.ok(monitor.timer.notCalled, 'monitor.timer was not called')
-            assert.ok(timer.stop.notCalled, 'timer stop was not called')
+            sinon.assert.calledOnce(monitor.timer)
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer', {
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
           })
       })
-
-      describe('with monitoring', function () {
-        beforeEach(function () {
-          process.env.WORKER_MONITOR = true
-        })
-        afterEach(function () {
-          delete process.env.WORKER_MONITOR
-        })
-        it('should run the task and monitor call', function () {
-          taskHandler = sinon.stub()
-          doneHandler = sinon.stub()
-          return assert.isFulfilled(worker.run())
-            .then(function () {
-              assert.ok(taskHandler.calledOnce, 'task was called once')
-              assert.ok(doneHandler.calledOnce, 'done was called once')
-              sinon.assert.calledTwice(monitor.increment)
-              sinon.assert.calledWith(monitor.increment.firstCall, 'ponos', {
-                token0: 'command',
-                token1: 'something.command',
-                token2: 'do.something.command',
-                queue: 'do.something.command'
-              })
-              sinon.assert.calledWith(monitor.increment.secondCall, 'ponos.finish', {
-                result: 'success',
-                token0: 'command',
-                token1: 'something.command',
-                token2: 'do.something.command',
-                queue: 'do.something.command'
-              })
-              sinon.assert.calledOnce(monitor.timer)
-              sinon.assert.calledWith(monitor.timer, 'ponos.timer', {
-                token0: 'command',
-                token1: 'something.command',
-                token2: 'do.something.command',
-                queue: 'do.something.command'
-              })
-            })
-        })
-      })
-
       describe('with worker timeout', function () {
         var prevTimeout
 
@@ -295,57 +260,23 @@ describe('Worker', function () {
                 token0: 'command',
                 token1: 'something.command',
                 token2: 'do.something.command',
-                queue: 'do.something.command' })
+                queue: 'do.something.command'
+              })
               sinon.assert.calledWith(monitor.increment.secondCall, 'ponos.finish', {
                 result: 'timeout-error',
                 token0: 'command',
                 token1: 'something.command',
                 token2: 'do.something.command',
-                queue: 'do.something.command' })
-            })
-        })
-        describe('with monitoring', function () {
-          beforeEach(function () {
-            process.env.WORKER_MONITOR = true
-          })
-          afterEach(function () {
-            delete process.env.WORKER_MONITOR
-          })
-          it('should timeout the job', function () {
-            // we are going to replace the handler w/ a stub
-            taskHandler = function () {
-              taskHandler = sinon.stub()
-              return Promise.resolve().delay(25)
-            }
-            doneHandler = sinon.stub()
-            return assert.isFulfilled(worker.run())
-              .then(function () {
-                // this is asserting taskHandler called once, but was twice
-                assert.ok(taskHandler.calledOnce, 'task was called once')
-                assert.ok(doneHandler.calledOnce, 'done was called once')
-                sinon.assert.callCount(monitor.increment, 5)
-                sinon.assert.calledWith(monitor.increment.firstCall, 'ponos', {
-                  token0: 'command',
-                  token1: 'something.command',
-                  token2: 'do.something.command',
-                  queue: 'do.something.command'
-                })
-                sinon.assert.calledWith(monitor.increment.secondCall, 'ponos.finish', {
-                  result: 'timeout-error',
-                  token0: 'command',
-                  token1: 'something.command',
-                  token2: 'do.something.command',
-                  queue: 'do.something.command'
-                 })
-                sinon.assert.calledTwice(monitor.timer)
-                sinon.assert.calledTwice(monitor.timer, 'ponos.timer', {
-                  token0: 'command',
-                  token1: 'something.command',
-                  token2: 'do.something.command',
-                  queue: 'do.something.command'
-                })
+                queue: 'do.something.command'
               })
-          })
+              sinon.assert.calledTwice(monitor.timer)
+              sinon.assert.calledWith(monitor.timer, 'ponos.timer', {
+                token0: 'command',
+                token1: 'something.command',
+                token2: 'do.something.command',
+                queue: 'do.something.command'
+              })
+            })
         })
       })
 
@@ -406,6 +337,13 @@ describe('Worker', function () {
             })
             sinon.assert.calledWith(monitor.increment.secondCall, 'ponos.finish', {
               result: 'fatal-error',
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
+            sinon.assert.calledOnce(monitor.timer)
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer', {
               token0: 'command',
               token1: 'something.command',
               token2: 'do.something.command',
@@ -481,6 +419,13 @@ describe('Worker', function () {
             })
             sinon.assert.calledWith(monitor.increment.secondCall, 'ponos.finish', {
               result: 'task-error',
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
+            sinon.assert.calledTwice(monitor.timer)
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer', {
               token0: 'command',
               token1: 'something.command',
               token2: 'do.something.command',

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -239,6 +239,50 @@ describe('Worker', function () {
     })
   })
 
+  describe('_createTimer', function () {
+    var worker
+    var queue = 'do.something.command'
+
+    beforeEach(function () {
+      sinon.stub(monitor, 'timer').returns({ stop: function () {} })
+      worker = Worker.create(put({ runNow: false }, opts))
+      worker.queue = queue
+    })
+
+    afterEach(function () {
+      monitor.timer.restore()
+    })
+
+    it('should call monitor.timer for event without result tag', function () {
+      var timer = worker._createTimer()
+      assert.isNotNull(timer)
+      assert.isNotNull(timer.stop)
+      sinon.assert.calledOnce(monitor.timer)
+      sinon.assert.calledWith(monitor.timer, 'ponos.timer', true, {
+        token0: 'command',
+        token1: 'something.command',
+        token2: 'do.something.command',
+        queue: 'do.something.command'
+      })
+    })
+
+    describe('with disabled monitoring', function () {
+      beforeEach(function () {
+        process.env.WORKER_MONITOR_DISABLED = 'true'
+      })
+
+      afterEach(function () {
+        delete process.env.WORKER_MONITOR_DISABLED
+      })
+
+      it('should not call monitor.timer', function () {
+        var timer = worker._createTimer()
+        assert.isNull(timer)
+        sinon.assert.notCalled(monitor.timer)
+      })
+    })
+  })
+
   describe('run', function () {
     var worker
     var timer = {
@@ -282,13 +326,12 @@ describe('Worker', function () {
               queue: 'do.something.command'
             })
             sinon.assert.calledOnce(monitor.timer)
-            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
-              !process.env.WORKER_MONITOR_DISABLED, {
-                token0: 'command',
-                token1: 'something.command',
-                token2: 'do.something.command',
-                queue: 'do.something.command'
-              })
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer', true, {
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
             sinon.assert.calledOnce(timer.stop)
           })
       })
@@ -310,15 +353,8 @@ describe('Worker', function () {
               assert.ok(taskHandler.calledOnce, 'task was called once')
               assert.ok(doneHandler.calledOnce, 'done was called once')
               sinon.assert.notCalled(monitor.increment)
-              sinon.assert.calledOnce(monitor.timer)
-              sinon.assert.calledWith(monitor.timer, 'ponos.timer',
-                !process.env.WORKER_MONITOR_DISABLED, {
-                  token0: 'command',
-                  token1: 'something.command',
-                  token2: 'do.something.command',
-                  queue: 'do.something.command'
-                })
-              sinon.assert.calledOnce(timer.stop)
+              sinon.assert.notCalled(monitor.timer)
+              sinon.assert.notCalled(timer.stop)
             })
         })
       })
@@ -359,13 +395,12 @@ describe('Worker', function () {
                 queue: 'do.something.command'
               })
               sinon.assert.calledTwice(monitor.timer)
-              sinon.assert.calledWith(monitor.timer, 'ponos.timer',
-                !process.env.WORKER_MONITOR_DISABLED, {
-                  token0: 'command',
-                  token1: 'something.command',
-                  token2: 'do.something.command',
-                  queue: 'do.something.command'
-                })
+              sinon.assert.calledWith(monitor.timer, 'ponos.timer', true, {
+                token0: 'command',
+                token1: 'something.command',
+                token2: 'do.something.command',
+                queue: 'do.something.command'
+              })
               sinon.assert.calledTwice(timer.stop)
             })
         })
@@ -434,13 +469,12 @@ describe('Worker', function () {
               queue: 'do.something.command'
             })
             sinon.assert.calledOnce(monitor.timer)
-            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
-              !process.env.WORKER_MONITOR_DISABLED, {
-                token0: 'command',
-                token1: 'something.command',
-                token2: 'do.something.command',
-                queue: 'do.something.command'
-              })
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer', true, {
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
             sinon.assert.calledOnce(timer.stop)
           })
       })
@@ -467,13 +501,12 @@ describe('Worker', function () {
               queue: 'do.something.command'
             })
             sinon.assert.calledTwice(monitor.timer)
-            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
-              !process.env.WORKER_MONITOR_DISABLED, {
-                token0: 'command',
-                token1: 'something.command',
-                token2: 'do.something.command',
-                queue: 'do.something.command'
-              })
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer', true, {
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
             sinon.assert.calledTwice(timer.stop)
           })
       })
@@ -500,13 +533,12 @@ describe('Worker', function () {
               queue: 'do.something.command'
             })
             sinon.assert.calledTwice(monitor.timer)
-            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
-              !process.env.WORKER_MONITOR_DISABLED, {
-                token0: 'command',
-                token1: 'something.command',
-                token2: 'do.something.command',
-                queue: 'do.something.command'
-              })
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer', true, {
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
             sinon.assert.calledTwice(timer.stop)
           })
       })
@@ -533,13 +565,12 @@ describe('Worker', function () {
               queue: 'do.something.command'
             })
             sinon.assert.calledTwice(monitor.timer)
-            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
-              !process.env.WORKER_MONITOR_DISABLED, {
-                token0: 'command',
-                token1: 'something.command',
-                token2: 'do.something.command',
-                queue: 'do.something.command'
-              })
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer', true, {
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
             sinon.assert.calledTwice(timer.stop)
           })
       })
@@ -587,13 +618,12 @@ describe('Worker', function () {
               queue: 'do.something.command'
             })
             sinon.assert.calledTwice(monitor.timer)
-            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
-              !process.env.WORKER_MONITOR_DISABLED, {
-                token0: 'command',
-                token1: 'something.command',
-                token2: 'do.something.command',
-                queue: 'do.something.command'
-              })
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer', true, {
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
             sinon.assert.calledTwice(timer.stop)
           })
       })

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -194,7 +194,7 @@ describe('Worker', function () {
       worker = Worker.create(put({ runNow: false }, opts))
       worker.queue = queue
     })
-    
+
     afterEach(function () {
       monitor.increment.restore()
     })

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -151,6 +151,38 @@ describe('Worker', function () {
     })
   })
 
+  describe('_eventTags', function () {
+    var worker
+    var queue = 'some.queue.name'
+
+    beforeEach(function () {
+      worker = Worker.create(opts)
+      worker.queue = queue
+    })
+    it('should generate tags for new style queues', function () {
+      var tags = worker._eventTags()
+      assert.isObject(tags)
+      assert.equal(Object.keys(tags).length, 4)
+      assert.deepEqual(tags, {
+        queue: queue,
+        token0: 'name',
+        token1: 'queue.name',
+        token2: 'some.queue.name'
+      })
+    })
+    it('should generate tags for old style queues', function () {
+      var queue = 'some-queue-name'
+      worker.queue = queue
+      var tags = worker._eventTags()
+      assert.isObject(tags)
+      assert.equal(Object.keys(tags).length, 2)
+      assert.deepEqual(tags, {
+        queue: queue,
+        token0: 'some-queue-name'
+      })
+    })
+  })
+
   describe('run', function () {
     var worker
     var timer = {
@@ -201,15 +233,15 @@ describe('Worker', function () {
               assert.ok(doneHandler.calledOnce, 'done was called once')
               assert.ok(monitor.increment.calledOnce, 'monitor.inc was called once')
               assert.ok(monitor.increment.calledWith('ponos',
-                { 'token-0': 'command',
-                  'token-1': 'something.command',
-                  'token-2': 'do.something.command',
+                { 'token0': 'command',
+                  'token1': 'something.command',
+                  'token2': 'do.something.command',
                   queue: 'do.something.command' }), 'monitor.inc was called once with args')
               assert.ok(monitor.timer.calledOnce, 'monitor.timer was called once')
               assert.ok(monitor.timer.calledWith('ponos.timer',
-                { 'token-0': 'command',
-                  'token-1': 'something.command',
-                  'token-2': 'do.something.command',
+                { 'token0': 'command',
+                  'token1': 'something.command',
+                  'token2': 'do.something.command',
                   queue: 'do.something.command' }), 'monitor.inc was called once with args')
               assert.ok(timer.stop.calledOnce, 'timer.stop was called once')
             })

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -172,6 +172,7 @@ describe('Worker', function () {
         token2: 'some.queue.name'
       })
     })
+
     it('should generate tags for old style queues', function () {
       var queue = 'some-queue-name'
       worker.queue = queue
@@ -185,7 +186,7 @@ describe('Worker', function () {
     })
   })
 
-  describe('_inc', function () {
+  describe('_incMonitor', function () {
     var worker
     var queue = 'do.something.command'
 
@@ -200,7 +201,7 @@ describe('Worker', function () {
     })
 
     it('should call monitor increment for event without result tag', function () {
-      worker._inc('ponos')
+      worker._incMonitor('ponos')
       sinon.assert.calledOnce(monitor.increment)
       sinon.assert.calledWith(monitor.increment, 'ponos', {
         token0: 'command',
@@ -209,8 +210,9 @@ describe('Worker', function () {
         queue: 'do.something.command'
       })
     })
+
     it('should call monitor increment for event with extra tags', function () {
-      worker._inc('ponos.finish', { result: 'success' })
+      worker._incMonitor('ponos.finish', { result: 'success' })
       sinon.assert.calledOnce(monitor.increment)
       sinon.assert.calledWith(monitor.increment, 'ponos.finish', {
         token0: 'command',
@@ -220,6 +222,7 @@ describe('Worker', function () {
         result: 'success'
       })
     })
+
     describe('with disabled monitoring', function () {
       beforeEach(function () {
         process.env.WORKER_MONITOR_DISABLED = 'true'
@@ -230,7 +233,7 @@ describe('Worker', function () {
       })
 
       it('should not call monitor increment', function () {
-        worker._inc('ponos.finish', { result: 'success' })
+        worker._incMonitor('ponos.finish', { result: 'success' })
         sinon.assert.notCalled(monitor.increment)
       })
     })
@@ -289,6 +292,7 @@ describe('Worker', function () {
             sinon.assert.calledOnce(timer.stop)
           })
       })
+      
       describe('with disabled monitoring', function () {
         beforeEach(function () {
           process.env.WORKER_MONITOR_DISABLED = 'true'

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -5,6 +5,7 @@ var assert = chai.assert
 var sinon = require('sinon')
 
 var Promise = require('bluebird')
+var monitor = require('monitor-dog')
 var TaskError = require('../../lib/errors/task-error')
 var TaskFatalError = require('../../lib/errors/task-fatal-error')
 var TimeoutError = Promise.TimeoutError
@@ -156,6 +157,11 @@ describe('Worker', function () {
     beforeEach(function () {
       opts.runNow = false
       worker = Worker.create(opts)
+      sinon.spy(monitor, 'increment')
+    })
+
+    afterEach(function () {
+      monitor.increment.restore()
     })
 
     describe('successful runs', function () {
@@ -166,6 +172,7 @@ describe('Worker', function () {
           .then(function () {
             assert.ok(taskHandler.calledOnce, 'task was called once')
             assert.ok(doneHandler.calledOnce, 'done was called once')
+            assert.ok(monitor.increment.notCalled, 'monitor wasnot called')
           })
       })
 

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -274,13 +274,42 @@ describe('Worker', function () {
               queue: 'do.something.command'
             })
             sinon.assert.calledOnce(monitor.timer)
-            sinon.assert.calledWith(monitor.timer, 'ponos.timer', {
-              token0: 'command',
-              token1: 'something.command',
-              token2: 'do.something.command',
-              queue: 'do.something.command'
-            })
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
+              !process.env.WORKER_MONITOR_DISABLED, {
+                token0: 'command',
+                token1: 'something.command',
+                token2: 'do.something.command',
+                queue: 'do.something.command'
+              })
+            sinon.assert.calledOnce(timer.stop)
           })
+      })
+      describe('with disabled monitoring', function () {
+        beforeEach(function () {
+          process.env.WORKER_MONITOR_DISABLED = 'true'
+        })
+        afterEach(function () {
+          delete process.env.WORKER_MONITOR_DISABLED
+        })
+        it('should run the task and call done and not stop timer', function () {
+          taskHandler = sinon.stub()
+          doneHandler = sinon.stub()
+          return assert.isFulfilled(worker.run())
+            .then(function () {
+              assert.ok(taskHandler.calledOnce, 'task was called once')
+              assert.ok(doneHandler.calledOnce, 'done was called once')
+              sinon.assert.notCalled(monitor.increment)
+              sinon.assert.calledOnce(monitor.timer)
+              sinon.assert.calledWith(monitor.timer, 'ponos.timer',
+                !process.env.WORKER_MONITOR_DISABLED, {
+                  token0: 'command',
+                  token1: 'something.command',
+                  token2: 'do.something.command',
+                  queue: 'do.something.command'
+                })
+              sinon.assert.calledOnce(timer.stop)
+            })
+        })
       })
       describe('with worker timeout', function () {
         var prevTimeout
@@ -319,12 +348,14 @@ describe('Worker', function () {
                 queue: 'do.something.command'
               })
               sinon.assert.calledTwice(monitor.timer)
-              sinon.assert.calledWith(monitor.timer, 'ponos.timer', {
-                token0: 'command',
-                token1: 'something.command',
-                token2: 'do.something.command',
-                queue: 'do.something.command'
-              })
+              sinon.assert.calledWith(monitor.timer, 'ponos.timer',
+                !process.env.WORKER_MONITOR_DISABLED, {
+                  token0: 'command',
+                  token1: 'something.command',
+                  token2: 'do.something.command',
+                  queue: 'do.something.command'
+                })
+              sinon.assert.calledTwice(timer.stop)
             })
         })
       })
@@ -392,12 +423,14 @@ describe('Worker', function () {
               queue: 'do.something.command'
             })
             sinon.assert.calledOnce(monitor.timer)
-            sinon.assert.calledWith(monitor.timer, 'ponos.timer', {
-              token0: 'command',
-              token1: 'something.command',
-              token2: 'do.something.command',
-              queue: 'do.something.command'
-            })
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
+              !process.env.WORKER_MONITOR_DISABLED, {
+                token0: 'command',
+                token1: 'something.command',
+                token2: 'do.something.command',
+                queue: 'do.something.command'
+              })
+            sinon.assert.calledOnce(timer.stop)
           })
       })
 
@@ -408,6 +441,29 @@ describe('Worker', function () {
           .then(function () {
             assert.equal(taskHandler.callCount, 2, 'task was called twice')
             assert.ok(doneHandler.calledOnce, 'done was called once')
+            sinon.assert.callCount(monitor.increment, 4)
+            sinon.assert.calledWith(monitor.increment.firstCall, 'ponos', {
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
+            sinon.assert.calledWith(monitor.increment.secondCall, 'ponos.finish', {
+              result: 'task-error',
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
+            sinon.assert.calledTwice(monitor.timer)
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
+              !process.env.WORKER_MONITOR_DISABLED, {
+                token0: 'command',
+                token1: 'something.command',
+                token2: 'do.something.command',
+                queue: 'do.something.command'
+              })
+            sinon.assert.calledTwice(timer.stop)
           })
       })
 
@@ -418,6 +474,29 @@ describe('Worker', function () {
           .then(function () {
             assert.equal(taskHandler.callCount, 2, 'task was called twice')
             assert.ok(doneHandler.calledOnce, 'done was called once')
+            sinon.assert.callCount(monitor.increment, 4)
+            sinon.assert.calledWith(monitor.increment.firstCall, 'ponos', {
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
+            sinon.assert.calledWith(monitor.increment.secondCall, 'ponos.finish', {
+              result: 'task-error',
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
+            sinon.assert.calledTwice(monitor.timer)
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
+              !process.env.WORKER_MONITOR_DISABLED, {
+                token0: 'command',
+                token1: 'something.command',
+                token2: 'do.something.command',
+                queue: 'do.something.command'
+              })
+            sinon.assert.calledTwice(timer.stop)
           })
       })
 
@@ -428,6 +507,29 @@ describe('Worker', function () {
           .then(function () {
             assert.equal(taskHandler.callCount, 2, 'task was called twice')
             assert.ok(doneHandler.calledOnce, 'done was called once')
+            sinon.assert.callCount(monitor.increment, 5)
+            sinon.assert.calledWith(monitor.increment.firstCall, 'ponos', {
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
+            sinon.assert.calledWith(monitor.increment.secondCall, 'ponos.finish', {
+              result: 'timeout-error',
+              token0: 'command',
+              token1: 'something.command',
+              token2: 'do.something.command',
+              queue: 'do.something.command'
+            })
+            sinon.assert.calledTwice(monitor.timer)
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
+              !process.env.WORKER_MONITOR_DISABLED, {
+                token0: 'command',
+                token1: 'something.command',
+                token2: 'do.something.command',
+                queue: 'do.something.command'
+              })
+            sinon.assert.calledTwice(timer.stop)
           })
       })
 
@@ -474,12 +576,14 @@ describe('Worker', function () {
               queue: 'do.something.command'
             })
             sinon.assert.calledTwice(monitor.timer)
-            sinon.assert.calledWith(monitor.timer, 'ponos.timer', {
-              token0: 'command',
-              token1: 'something.command',
-              token2: 'do.something.command',
-              queue: 'do.something.command'
-            })
+            sinon.assert.calledWith(monitor.timer, 'ponos.timer',
+              !process.env.WORKER_MONITOR_DISABLED, {
+                token0: 'command',
+                token1: 'something.command',
+                token2: 'do.something.command',
+                queue: 'do.something.command'
+              })
+            sinon.assert.calledTwice(timer.stop)
           })
       })
 

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -160,6 +160,7 @@ describe('Worker', function () {
       worker = Worker.create(opts)
       worker.queue = queue
     })
+
     it('should generate tags for new style queues', function () {
       var tags = worker._eventTags()
       assert.isObject(tags)
@@ -193,9 +194,11 @@ describe('Worker', function () {
       worker = Worker.create(put({ runNow: false }, opts))
       worker.queue = queue
     })
+    
     afterEach(function () {
       monitor.increment.restore()
     })
+
     it('should call monitor increment for event without result tag', function () {
       worker._inc('ponos')
       sinon.assert.calledOnce(monitor.increment)
@@ -221,9 +224,11 @@ describe('Worker', function () {
       beforeEach(function () {
         process.env.WORKER_MONITOR_DISABLED = 'true'
       })
+
       afterEach(function () {
         delete process.env.WORKER_MONITOR_DISABLED
       })
+
       it('should not call monitor increment', function () {
         worker._inc('ponos.finish', { result: 'success' })
         sinon.assert.notCalled(monitor.increment)
@@ -288,9 +293,11 @@ describe('Worker', function () {
         beforeEach(function () {
           process.env.WORKER_MONITOR_DISABLED = 'true'
         })
+
         afterEach(function () {
           delete process.env.WORKER_MONITOR_DISABLED
         })
+
         it('should run the task and call done and not stop timer', function () {
           taskHandler = sinon.stub()
           doneHandler = sinon.stub()


### PR DESCRIPTION
Add counter and timer for all ponos jobs. Hidden behind flag.

- increment for all started jobs
- increment for all jobs results: success, timeout error, fatal error, task error
- ponos.timer to track how long each task execution took

Tasks:

- [x] please merge https://github.com/Runnable/monitor-dog/pull/11 first
- [x] use merged version of monitor-dog
- [x] review
- [ ] demo