### PR TITLE
package.json engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.3.1",
   "description": "An opinionated queue based worker server for node.",
   "main": "index.js",
+  "engines": {
+    "node": ">=4 <5"
+  },
   "scripts": {
     "changelog": "github-changes -o Runnable -r ponos -a --only-pulls --use-commit-body --order-semver",
     "coverage": "istanbul cover ./node_modules/.bin/_mocha -- $npm_package_options_mocha test/unit && npm run coverage-check",


### PR DESCRIPTION
Specifying the node engine with which this package will work. Since it needs node 4, this is a good thing. Since we're not testing against node 5 and guaranteeing support, I exclude it here.

[docs on engines](https://docs.npmjs.com/files/package.json#engines)