### PR TITLE
clear channel and connection on disconnect

### DIFF
--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -289,6 +289,10 @@ class RabbitMQ {
       return Promise.reject(new Error('not connected. cannot disconnect.'))
     }
     return Promise.resolve(this.connection.close())
+      .then(() => {
+        delete this.channel
+        delete this.connection
+      })
   }
 
   // Private Methods

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -60,9 +60,7 @@ class RabbitMQ {
         'constructor documentation.'
       )
     }
-    this.subscriptions = new Immutable.Map()
-    this.subscribed = new Immutable.Set()
-    this.consuming = new Immutable.Map()
+    this._setCleanState()
     return this
   }
 
@@ -290,12 +288,24 @@ class RabbitMQ {
     }
     return Promise.resolve(this.connection.close())
       .then(() => {
-        delete this.channel
-        delete this.connection
+        this._setCleanState()
       })
   }
 
   // Private Methods
+
+  /**
+   * Helper method to re-set the state of the model to be 'clean'.
+   *
+   * @private
+   */
+  _setCleanState (): void {
+    delete this.channel
+    delete this.connection
+    this.subscriptions = new Immutable.Map()
+    this.subscribed = new Immutable.Set()
+    this.consuming = new Immutable.Map()
+  }
 
   /**
    * Error handler for the RabbitMQ connection.
@@ -311,6 +321,7 @@ class RabbitMQ {
 
   /**
    * Error handler for the RabbitMQ channel.
+   *
    * @private
    * @throws Error
    * @param {object} err Error object from event.

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -959,8 +959,10 @@ describe('rabbitmq', () => {
   })
 
   describe('disconnect', () => {
+    const connection = {}
+
     beforeEach(() => {
-      rabbitmq.connection = {}
+      rabbitmq.connection = connection
       rabbitmq.connection.close = sinon.stub().resolves()
     })
 
@@ -972,7 +974,16 @@ describe('rabbitmq', () => {
       it('should disconnect', () => {
         return assert.isFulfilled(rabbitmq.disconnect())
           .then(() => {
-            sinon.assert.calledOnce(rabbitmq.connection.close)
+            sinon.assert.calledOnce(connection.close)
+          })
+      })
+
+      it('should delete the connection and channel', () => {
+        rabbitmq.channel = {}
+        return assert.isFulfilled(rabbitmq.disconnect())
+          .then(() => {
+            assert.notOk(rabbitmq.channel)
+            assert.notOk(rabbitmq.connection)
           })
       })
     })
@@ -985,7 +996,7 @@ describe('rabbitmq', () => {
       it('should reject with error', () => {
         return assert.isRejected(rabbitmq.disconnect(), /not connected/)
           .then(() => {
-            sinon.assert.notCalled(rabbitmq.connection.close)
+            sinon.assert.notCalled(connection.close)
           })
       })
     })


### PR DESCRIPTION
as the title says - if we clear these, we can reconnect the model, which is useful. it will lose all it's subscriptions, but I think that's okay. this is mostly for testing purposes anyway for other projects when they want to use the rabbitmq model

fixes #39 