### PR TITLE
Name RabbitMQ Client & Queues

### DIFF
--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -36,6 +36,7 @@ class RabbitMQ {
   consuming: Map<string, string>;
   hostname: string;
   log: Object;
+  name: string;
   password: string;
   port: number;
   subscribed: Set<string>;

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -72,7 +72,7 @@ class RabbitMQ {
    * @return {Promise} Promise that resolves once connection is established.
    */
   connect (): Promise {
-    if (this._isConnected()) {
+    if (this._isPartlyConnected() || this._isConnected()) {
       return Promise.reject(new Error('cannot call connect twice'))
     }
     let authString = ''

--- a/src/server.js
+++ b/src/server.js
@@ -33,6 +33,7 @@ const Worker = require('./worker')
  * @param {Object<String, Function>} [opts.events] Mapping of event (fanout)
  *   exchanges which to subscribe and handlers.
  * @param {bunyan} [opts.log] A bunyan logger to use for the server.
+ * @param {String} [opts.name] A name to namespace the created exchange queues.
  * @param {Object} [opts.rabbitmq] RabbitMQ connection options.
  * @param {String} [opts.rabbitmq.hostname] Hostname for RabbitMQ.
  * @param {Number} [opts.rabbitmq.port] Port for RabbitMQ.
@@ -66,7 +67,13 @@ class Server {
 
     this.errorCat = this._opts.errorCat || errorCat
 
-    this._rabbitmq = new RabbitMQ(this._opts.rabbitmq || {})
+    // add the name to RabbitMQ options
+    const rabbitmqOpts = defaults(
+      this._opts.rabbitmq || {},
+      { name: this._opts.name }
+    )
+    console.log(rabbitmqOpts)
+    this._rabbitmq = new RabbitMQ(rabbitmqOpts)
   }
 
   /**

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -93,11 +93,13 @@ describe('rabbitmq', () => {
   describe('connect', () => {
     beforeEach(() => {
       sinon.stub(RabbitMQ.prototype, '_isConnected').returns(false)
+      sinon.stub(RabbitMQ.prototype, '_isPartlyConnected').returns(false)
       sinon.stub(amqplib, 'connect').resolves(mockConnection)
     })
 
     afterEach(() => {
       RabbitMQ.prototype._isConnected.restore()
+      RabbitMQ.prototype._isPartlyConnected.restore()
       amqplib.connect.restore()
     })
 
@@ -105,11 +107,20 @@ describe('rabbitmq', () => {
       return assert.isFulfilled(rabbitmq.connect())
         .then(() => {
           sinon.assert.calledOnce(RabbitMQ.prototype._isConnected)
+          sinon.assert.calledOnce(RabbitMQ.prototype._isPartlyConnected)
         })
     })
 
     it('does not connect twice', () => {
       RabbitMQ.prototype._isConnected.returns(true)
+      return assert.isRejected(
+        rabbitmq.connect(),
+        /cannot call connect twice/
+      )
+    })
+
+    it('does not connect twice if partly connected', () => {
+      RabbitMQ.prototype._isPartlyConnected.returns(true)
       return assert.isRejected(
         rabbitmq.connect(),
         /cannot call connect twice/

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -107,6 +107,21 @@ describe('Server', () => {
       })
       assert.equal(s._rabbitmq.hostname, 'foobar')
     })
+
+    it('should default the name of the rabbitmq client to ponos', () => {
+      const s = new ponos.Server({
+        rabbitmq: { hostname: 'foobar' }
+      })
+      assert.equal(s._rabbitmq.name, 'ponos')
+    })
+
+    it('should should name the rabbitmq client if we named our server', () => {
+      const s = new ponos.Server({
+        name: 'my-awesome-ponos-server',
+        rabbitmq: { hostname: 'foobar' }
+      })
+      assert.equal(s._rabbitmq.name, 'my-awesome-ponos-server')
+    })
   })
 
   describe('consume', () => {


### PR DESCRIPTION
Let's add the ability to namespace the queues we create to connect to fanout exchanges. That would be great, no?

Fixes #37 