### PR TITLE
Publish methods

### DIFF
--- a/interfaces/modules/amqplib.js.flow
+++ b/interfaces/modules/amqplib.js.flow
@@ -14,6 +14,8 @@ declare class RabbitMQChannel {
   cancel(consumerTag: string): Promise<void>;
   consume(queue: string, handler: Function): void;
   on(event: string, handler: Function): void;
+  publish(exchange: string, routingKey: string, content: Buffer): Promise<void>;
+  sendToQueue(queue: string, content: Buffer): Promise<void>;
 }
 
 type QueueObject = {

--- a/interfaces/modules/bluebird.js.flow
+++ b/interfaces/modules/bluebird.js.flow
@@ -17,6 +17,7 @@ declare class Promise<R> {
   ): Promise<Array<U>>;
   static reject<T>(error?: any): Promise<T>;
   static resolve<T>(object?: Promise<T> | T): Promise<T>;
+  static try<T>(fn: () => T|Promise<T>, args: ?Array<any>, ctx: ?any): Promise<T>;
 
   constructor(callback: (
   resolve: (result?: Promise<R> | R) => void,

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -23,10 +23,14 @@ const logger = require('./logger')
  *
  * @author Bryan Kendall
  * @param {Object} [opts] RabbitMQ connection options.
- * @param {String} [opts.hostname] Hostname for RabbitMQ.
- * @param {Number} [opts.port] Port for RabbitMQ.
- * @param {String} [opts.username] Username for RabbitMQ.
- * @param {String} [opts.password] Username for Password.
+ * @param {String} [opts.hostname=localhost] Hostname for RabbitMQ. Can be set
+ *   with environment variable RABBITMQ_HOSTNAME.
+ * @param {Number} [opts.port=5672] Port for RabbitMQ. Can be set with
+ *   environment variable RABBITMQ_PORT.
+ * @param {String} [opts.username] Username for RabbitMQ. Can be set with
+ *   environment variable RABBITMQ_USERNAME.
+ * @param {String} [opts.password] Username for Password. Can be set with
+ *   environment variable RABBITMQ_PASSWORD.
  */
 class RabbitMQ {
   static AMQPLIB_QUEUE_DEFAULTS: Object;

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -130,9 +130,9 @@ class RabbitMQ {
       if (!isObject(content)) {
         throw new Error('content must be an object')
       }
-      content = JSON.stringify(content)
-      content = new Buffer(content)
-      return Promise.resolve(this.channel.sendToQueue(queue, content))
+      const stringContent = JSON.stringify(content)
+      const bufferContent = new Buffer(stringContent)
+      return Promise.resolve(this.channel.sendToQueue(queue, bufferContent))
     })
   }
 
@@ -175,10 +175,10 @@ class RabbitMQ {
       if (!isObject(content)) {
         throw new Error('content must be an object')
       }
-      content = JSON.stringify(content)
-      content = new Buffer(content)
+      const stringContent = JSON.stringify(content)
+      const bufferContent = new Buffer(stringContent)
       return Promise
-        .resolve(this.channel.publish(exchange, routingKey, content))
+        .resolve(this.channel.publish(exchange, routingKey, bufferContent))
     })
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -76,7 +76,6 @@ class Server {
       this._opts.rabbitmq || {},
       { name: this._opts.name }
     )
-    console.log(rabbitmqOpts)
     this._rabbitmq = new RabbitMQ(rabbitmqOpts)
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -33,12 +33,16 @@ const Worker = require('./worker')
  * @param {Object<String, Function>} [opts.events] Mapping of event (fanout)
  *   exchanges which to subscribe and handlers.
  * @param {bunyan} [opts.log] A bunyan logger to use for the server.
- * @param {String} [opts.name] A name to namespace the created exchange queues.
+ * @param {String} [opts.name=ponos] A name to namespace the created exchange queues.
  * @param {Object} [opts.rabbitmq] RabbitMQ connection options.
- * @param {String} [opts.rabbitmq.hostname] Hostname for RabbitMQ.
- * @param {Number} [opts.rabbitmq.port] Port for RabbitMQ.
- * @param {String} [opts.rabbitmq.username] Username for RabbitMQ.
- * @param {String} [opts.rabbitmq.password] Username for Password.
+ * @param {String} [opts.rabbitmq.hostname=localhost] Hostname for RabbitMQ. Can
+ *   be set with environment variable RABBITMQ_HOSTNAME.
+ * @param {Number} [opts.rabbitmq.port=5672] Port for RabbitMQ. Can be set with
+ *   environment variable RABBITMQ_PORT.
+ * @param {String} [opts.rabbitmq.username] Username for RabbitMQ. Can be set
+ *   with environment variable RABBITMQ_USERNAME.
+ * @param {String} [opts.rabbitmq.password] Username for Password. Can be set
+ *   with environment variable RABBITMQ_PASSWORD.
  * @param {Object<String, Function>} [opts.tasks] Mapping of queues to subscribe
  *   directly with handlers.
  */

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -242,7 +242,7 @@ describe('rabbitmq', () => {
       RabbitMQ.prototype._isConnected.restore()
     })
 
-    it('should reject if we are not conencted', () => {
+    it('should reject if we are not connected', () => {
       RabbitMQ.prototype._isConnected.returns(false)
       return assert.isRejected(
         rabbitmq.publishToQueue(mockQueue, mockJob),
@@ -313,7 +313,7 @@ describe('rabbitmq', () => {
       Bunyan.prototype.info.restore()
     })
 
-    it('should reject if we are not conencted', () => {
+    it('should reject if we are not connected', () => {
       RabbitMQ.prototype._isConnected.returns(false)
       return assert.isRejected(
         rabbitmq.publishToExchange(mockExchange, mockRoutingKey, mockJob),


### PR DESCRIPTION
Adds two methods to the RabbitMQ model:

- `publishToQueue(queue, content)`
- `publishToExchange(exchange, routingKey, content)`

Made the model public in the documentation and exposed only the above two methods and `connect` and `disconnect` in the documentation.

Updated the examples and tests accordingly.

Fixes #38 