### PR TITLE
Confirm Publish

### DIFF
--- a/interfaces/modules/amqplib.js.flow
+++ b/interfaces/modules/amqplib.js.flow
@@ -4,6 +4,7 @@ declare class RabbitMQConnection {
   on(event: string, handler: Function): void;
   close(): Promise<void>;
   createChannel(): RabbitMQChannel;
+  createConfirmChannel(): RabbitMQConfirmChannel;
 }
 
 declare class RabbitMQChannel {
@@ -16,6 +17,10 @@ declare class RabbitMQChannel {
   on(event: string, handler: Function): void;
   publish(exchange: string, routingKey: string, content: Buffer): Promise<void>;
   sendToQueue(queue: string, content: Buffer): Promise<void>;
+}
+
+declare class RabbitMQConfirmChannel extends RabbitMQChannel {
+  waitForConfirms(): Promise<void>;
 }
 
 type QueueObject = {

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -141,7 +141,6 @@ class RabbitMQ {
       const bufferContent = new Buffer(stringContent)
       return Promise
         .resolve(this.publishChannel.sendToQueue(queue, bufferContent))
-        .then(() => (this.publishChannel.waitForConfirms()))
     })
   }
 
@@ -189,7 +188,6 @@ class RabbitMQ {
       return Promise.resolve(
         this.publishChannel.publish(exchange, routingKey, bufferContent)
       )
-        .then(() => (this.publishChannel.waitForConfirms()))
     })
   }
 
@@ -380,10 +378,9 @@ class RabbitMQ {
     if (!this._isPartlyConnected()) {
       return Promise.reject(new Error('not connected. cannot disconnect.'))
     }
-    return Promise.resolve(this.connection.close())
-      .then(() => {
-        this._setCleanState()
-      })
+    return Promise.resolve(this.publishChannel.waitForConfirms())
+      .then(() => (Promise.resolve(this.connection.close())))
+      .then(() => (this._setCleanState()))
   }
 
   // Private Methods


### PR DESCRIPTION
In order to make the `.publishTo*` methods ensure they _actually_ publish when they resolve, I have to use a "confirm queue" through `amqplib` to make sure that things are confirmed when published. Requires setting up a second channel (which was a thought originally anyway), but does make for better reliability when publishing messages.