### PR TITLE
make publish methods more clear

### DIFF
--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -132,13 +132,13 @@ class RabbitMQ {
   }
 
   /**
-   * Takes an object representing a message and sends it to a queue.
+   * Takes an object representing a message and sends it to a task queue.
    *
-   * @param {String} queue Queue to receive the message.
-   * @param {Object} content Content to send.
+   * @param {String} queue Task queue to receive the message.
+   * @param {Object} content Job to send.
    * @return {Promise} Promise resolved when message is sent to queue.
    */
-  publishToQueue (queue: string, content: Object): Promise {
+  publishTask (queue: string, content: Object): Promise {
     return Promise.try(() => {
       if (!this._isConnected()) {
         throw new Error('you must call .connect() before publishing')
@@ -158,23 +158,14 @@ class RabbitMQ {
   }
 
   /**
-   * Takes an object representing a message and sends it to an exchange using
-   * a provided routing key.
-   *
-   * Note: Providing an empty string as the routing key is functionally the same
-   * as sending the message directly to a named queue. The function
-   * {@link RabbitMQ#publishToQueue} is preferred in this case.
+   * Sends an object representing a message to an exchange for the specified
+   * event.
    *
    * @param {String} queue Exchange to receive the message.
-   * @param {String} routingKey Routing Key for the exchange.
    * @param {Object} content Content to send.
    * @return {Promise} Promise resolved when message is sent to the exchange.
    */
-  publishToExchange (
-    exchange: string,
-    routingKey: string,
-    content: Object
-  ): Promise {
+  publishEvent (exchange: string, content: Object): Promise {
     return Promise.try(() => {
       if (!this._isConnected()) {
         throw new Error('you must call .connect() before publishing')
@@ -183,23 +174,14 @@ class RabbitMQ {
       if (!isString(exchange) || exchange === '') {
         throw new Error('exchange name must be a string')
       }
-      if (!isString(routingKey)) {
-        throw new Error('routingKey must be a string')
-      }
-      if (routingKey === '') {
-        this.log.info({
-          method: 'publishToExchange',
-          exchange: exchange
-        }, 'setting routingKey to empty string is the same as publishing to ' +
-          'a queue directly. use `publishToQueue` to ignore this message.')
-      }
       if (!isObject(content)) {
         throw new Error('content must be an object')
       }
       const stringContent = JSON.stringify(content)
       const bufferContent = new Buffer(stringContent)
+      // events do not need a routing key (so we send '')
       return Promise.resolve(
-        this.publishChannel.publish(exchange, routingKey, bufferContent)
+        this.publishChannel.publish(exchange, '', bufferContent)
       )
     })
   }

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -132,6 +132,52 @@ class RabbitMQ {
   }
 
   /**
+   * Takes an object representing a message and sends it to a queue.
+   *
+   * @deprecated
+   * @param {String} queue Queue to receive the message.
+   * @param {Object} content Content to send.
+   * @return {Promise} Promise resolved when message is sent to queue.
+   */
+  publishToQueue (queue: string, content: Object): Promise {
+    return Promise.try(() => {
+      this.log.warn({
+        method: 'publishToQueue',
+        queue
+      }, 'rabbitmq.publishToQueue is deprecated. use `publishTask`.')
+      return this.publishTask(queue, content)
+    })
+  }
+
+  /**
+   * Takes an object representing a message and sends it to an exchange using
+   * a provided routing key.
+   *
+   * Note: Providing an empty string as the routing key is functionally the same
+   * as sending the message directly to a named queue. The function
+   * {@link RabbitMQ#publishToQueue} is preferred in this case.
+   *
+   * @deprecated
+   * @param {String} queue Exchange to receive the message.
+   * @param {String} routingKey Routing Key for the exchange.
+   * @param {Object} content Content to send.
+   * @return {Promise} Promise resolved when message is sent to the exchange.
+   */
+  publishToExchange (
+    exchange: string,
+    routingKey: string,
+    content: Object
+  ): Promise {
+    return Promise.try(() => {
+      this.log.warn({
+        method: 'publishToExchange',
+        exchange
+      }, 'rabbitmq.publishToExchange is deprecated. use `publishEvent`.')
+      return this.publishEvent(exchange, content)
+    })
+  }
+
+  /**
    * Takes an object representing a message and sends it to a task queue.
    *
    * @param {String} queue Task queue to receive the message.

--- a/test/functional/basic.js
+++ b/test/functional/basic.js
@@ -42,6 +42,6 @@ describe('Basic Example', () => {
       eventName: 'task',
       message: 'hello world'
     }
-    rabbitmq.publishToQueue('ponos-test:one', job)
+    rabbitmq.publishTask('ponos-test:one', job)
   })
 })

--- a/test/functional/failing.js
+++ b/test/functional/failing.js
@@ -65,7 +65,7 @@ describe('Basic Failing Task', () => {
     testWorkerEmitter.on('will-never-emit', () => {
       throw new Error('failing worker should not have emitted')
     })
-    rabbitmq.publishToQueue('ponos-test:one', job)
+    rabbitmq.publishTask('ponos-test:one', job)
 
     // wait until .run is called
     return Promise.resolve().then(function loop () {

--- a/test/functional/timeout.js
+++ b/test/functional/timeout.js
@@ -103,7 +103,7 @@ describe('Basic Timeout Task', function () {
         })
       })
 
-      rabbitmq.publishToQueue('ponos-test:one', job)
+      rabbitmq.publishTask('ponos-test:one', job)
     })
   })
 })

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -280,6 +280,84 @@ describe('rabbitmq', () => {
     })
   })
 
+  describe('publishToQueue (deprecated)', () => {
+    beforeEach(() => {
+      sinon.stub(RabbitMQ.prototype, 'publishTask').resolves()
+      sinon.stub(Bunyan.prototype, 'warn')
+    })
+
+    afterEach(() => {
+      RabbitMQ.prototype.publishTask.restore()
+      Bunyan.prototype.warn.restore()
+    })
+
+    it('should call publishTask', () => {
+      const queue = 'mockQueue'
+      const content = {}
+      return assert
+        .isFulfilled(rabbitmq.publishToQueue(queue, content))
+        .then(() => {
+          sinon.assert.calledOnce(RabbitMQ.prototype.publishTask)
+          sinon.assert.calledWithExactly(
+            RabbitMQ.prototype.publishTask,
+            queue,
+            content
+          )
+        })
+    })
+
+    it('should log that it is deprecated', () => {
+      return assert.isFulfilled(rabbitmq.publishToQueue('queue', {}))
+        .then(() => {
+          sinon.assert.calledOnce(Bunyan.prototype.warn)
+          sinon.assert.calledWithExactly(
+            Bunyan.prototype.warn,
+            sinon.match.has('method', 'publishToQueue'),
+            sinon.match(/.+publishToQueue.+deprecated.+/)
+          )
+        })
+    })
+  })
+
+  describe('publishToExchange (deprecated)', () => {
+    beforeEach(() => {
+      sinon.stub(RabbitMQ.prototype, 'publishEvent').resolves()
+      sinon.stub(Bunyan.prototype, 'warn')
+    })
+
+    afterEach(() => {
+      RabbitMQ.prototype.publishEvent.restore()
+      Bunyan.prototype.warn.restore()
+    })
+
+    it('should call publishEvent', () => {
+      const exchange = 'mockExchange'
+      const content = {}
+      return assert
+        .isFulfilled(rabbitmq.publishToExchange(exchange, '', content))
+        .then(() => {
+          sinon.assert.calledOnce(RabbitMQ.prototype.publishEvent)
+          sinon.assert.calledWithExactly(
+            RabbitMQ.prototype.publishEvent,
+            exchange,
+            content
+          )
+        })
+    })
+
+    it('should log that it is deprecated', () => {
+      return assert.isFulfilled(rabbitmq.publishToExchange('exchange', '', {}))
+        .then(() => {
+          sinon.assert.calledOnce(Bunyan.prototype.warn)
+          sinon.assert.calledWithExactly(
+            Bunyan.prototype.warn,
+            sinon.match.has('method', 'publishToExchange'),
+            sinon.match(/.+publishToExchange.+deprecated.+/)
+          )
+        })
+    })
+  })
+
   describe('publishTask', () => {
     const mockQueue = 'some-queue'
     const mockJob = { hello: 'world' }


### PR DESCRIPTION
#### New Methods (no longer breaking)

The following methods have been added. the `publishTo*` methods have been deprecated and will be removed in a later release.

- `publishToQueue(queue, job)` has been replaced with `publishTask(queue, job)`
- `publishToExchange(exchange, routingKey, job)` has been replaced with `publishEvent(exchange, job)` (and assumes a routing key of `''`)

I did _not_ leave backwards support for these functions, though I suppose I could adjust this a bit and do that easily.

#### Reviewers

- [x] @anandkumarpatel 
- [x] @podviaznikov