### PR TITLE
Update ErrorCat@3.0.0

### DIFF
--- a/interfaces/modules/error-cat.js.flow
+++ b/interfaces/modules/error-cat.js.flow
@@ -7,7 +7,7 @@ declare module 'error-cat' {
 }
 
 declare class WorkerStopError extends Error {
-  static constructor(message: string, data?: Object, queue?: string, job: Object): WorkerStopError;
+  static constructor(message: string, data?: Object, reporting?: Object, queue?: string, job?: Object): WorkerStopError;
 }
 
 declare module 'error-cat/errors/worker-stop-error' {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "amqplib": "^0.4.1",
     "bluebird": "^3.0.5",
     "bunyan": "^1.5.1",
-    "error-cat": "^2.0.4",
+    "error-cat": "^3.0.0",
     "immutable": "^3.8.1",
     "monitor-dog": "1.5.0",
     "uuid": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
       "afterEach"
     ]
   },
+  "peerDependencies": {
+    "error-cat": "^3.0.0"
+  },
   "dependencies": {
     "101": "^1.1.1",
     "amqplib": "^0.4.1",

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -624,6 +624,7 @@ describe('Worker', () => {
           const stopError = new WorkerStopError(
             'my message',
             { dog: 'robot' },
+            { level: 'info' },
             'some.queue',
             { foo: 'bar' }
           )
@@ -632,6 +633,7 @@ describe('Worker', () => {
             .then(() => {
               const decoratedError = worker._reportError.firstCall.args[0]
               assert.deepEqual(decoratedError, stopError)
+              assert.deepEqual(decoratedError.reporting, { level: 'info' })
               assert.deepEqual(decoratedError.data.queue, 'some.queue')
               assert.deepEqual(decoratedError.data.job, { foo: 'bar' })
             })


### PR DESCRIPTION
Error-cat was updated to support `reporting` for the WorkerErrors: https://github.com/Runnable/error-cat/pull/29

## Breaking Changes

- error-cat updated to `v3` changes the signature of the `WorkerError` and `WorkerStopError`. projects updating w/ this change will need to upgrade error-cat as well
- added `error-cat@^3.0.0` as a peerDependency. what this will do is throw an error in `npm@2` or print a warning in `npm@3` if there is a mismatch.