### PR TITLE
codeclimate: ignore supporting folders

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,7 +23,10 @@ ratings:
   - "**.rb"
 exclude_paths:
 - coverage/
+- examples/
+- interfaces/
 - lib/
 - node_modules/
 - out/
+- resources/
 - test/


### PR DESCRIPTION
don't need codeclimate to be judging these folders.