### PR TITLE
add param to set max retry limit and a recovery function.

### DIFF
--- a/interfaces/modules/joi.js.flow
+++ b/interfaces/modules/joi.js.flow
@@ -1,0 +1,18 @@
+declare class Joi<T> {
+  static func(): T;
+  static object(): T;
+  static string(): T;
+  static required(): T;
+  static number(): T;
+  static bool(): T;
+  static assert(opts: Object, schema: T): T;
+  static validate(opts: Object, schema: T, opts: Object): JoiValidate;
+}
+
+declare class JoiValidate {
+  value: Object
+}
+
+declare module 'joi' {
+  declare var exports: typeof Joi;
+}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "continuation-local-storage": "^3.1.7",
     "error-cat": "^3.0.0",
     "immutable": "^3.8.1",
+    "joi": "^9.0.4",
     "monitor-dog": "1.5.0",
     "uuid": "^2.0.2"
   },

--- a/src/server.js
+++ b/src/server.js
@@ -9,7 +9,6 @@ const ErrorCat = require('error-cat')
 const Immutable = require('immutable')
 const isFunction = require('101/is-function')
 const isObject = require('101/is-object')
-const pick = require('101/pick')
 const Promise = require('bluebird')
 
 const logger = require('./logger')
@@ -212,10 +211,12 @@ class Server {
     if (!isFunction(task)) {
       throw new Error('ponos.server: setTask task handler must be a function')
     }
+    if (opts && !isObject(opts)) {
+      throw new Error('ponos.server: setTask opts must be a object')
+    }
+
     this._tasks = this._tasks.set(queueName, task)
-    this._workerOptions[queueName] = opts && isObject(opts)
-      ? pick(opts, 'msTimeout')
-      : {}
+    this._workerOptions[queueName] = opts || {}
     return this
   }
 
@@ -235,10 +236,12 @@ class Server {
     if (!isFunction(task)) {
       throw new Error('ponos.server: setEvent task handler must be a function')
     }
+    if (opts && !isObject(opts)) {
+      throw new Error('ponos.server: setEvent opts must be a object')
+    }
+
     this._events = this._events.set(exchangeName, task)
-    this._workerOptions[exchangeName] = opts && isObject(opts)
-      ? pick(opts, 'msTimeout')
-      : {}
+    this._workerOptions[exchangeName] = opts || {}
     return this
   }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -18,16 +18,16 @@ const TimeoutError = Promise.TimeoutError
 clsBlueBird(cls)
 
 const optsSchema = joi.object({
-  attempt: joi.number().required(),
+  attempt: joi.number().integer().min(0).required(),
   done: joi.func().required(),
   errorCat: joi.object(),
   finalRetryFn: joi.func(),
   job: joi.object().required(),
   log: joi.object().required(),
-  maxNumRetries: joi.number(),
-  msTimeout: joi.number().min(0),
+  maxNumRetries: joi.number().integer().min(0),
+  msTimeout: joi.number().integer().min(0),
   queue: joi.string().required(),
-  retryDelay: joi.number().required(),
+  retryDelay: joi.number().integer().min(0).required(),
   runNow: joi.bool(),
   task: joi.func().required()
 }).required()

--- a/src/worker.js
+++ b/src/worker.js
@@ -241,7 +241,7 @@ class Worker {
    * @private
    * @param {Error} err Error to report.
    */
-  _reportError (err: WorkerError): void {
+  _reportError (err: WorkerError|WorkerStopError): void {
     this.errorCat.report(err)
   }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -6,18 +6,29 @@ const cls = require('continuation-local-storage').createNamespace('ponos')
 const clsBlueBird = require('cls-bluebird')
 const defaults = require('101/defaults')
 const ErrorCat = require('error-cat')
-const exists = require('101/exists')
-const isNumber = require('101/is-number')
 const isObject = require('101/is-object')
+const joi = require('joi')
 const merge = require('101/put')
 const monitor = require('monitor-dog')
-const pick = require('101/pick')
 const Promise = require('bluebird')
 const uuid = require('uuid')
 const WorkerStopError = require('error-cat/errors/worker-stop-error')
 
 const TimeoutError = Promise.TimeoutError
 clsBlueBird(cls)
+
+const optsSchema = joi.object({
+  done: joi.func().required(),
+  job: joi.object().required(),
+  log: joi.object().required(),
+  queue: joi.string().required(),
+  task: joi.func().required(),
+  errorCat: joi.object(),
+  finalRetryFn: joi.func(),
+  maxNumRetries: joi.number(),
+  msTimeout: joi.number().positive(),
+  runNow: joi.bool()
+})
 
 /**
  * Performs tasks for jobs on a given queue.
@@ -44,8 +55,10 @@ class Worker {
   attempt: number;
   done: Function;
   errorCat: ErrorCat;
+  finalRetryFn: Function;
   job: Object;
   log: Logger;
+  maxNumRetries: number;
   msTimeout: number;
   queue: String;
   retryDelay: number;
@@ -54,28 +67,17 @@ class Worker {
 
   constructor (opts: Object) {
     // managed required fields
-    const fields = [
-      'done',
-      'job',
-      'log',
-      'queue',
-      'task'
-    ]
-    fields.forEach(function (f) {
-      if (!exists(opts[f])) {
-        throw new Error(f + ' is required for a Worker')
-      }
-    })
+    joi.assert(opts, optsSchema)
+    opts = joi.validate(opts, optsSchema, { stripUnknown: true }).value
 
-    // manage field defaults
-    fields.push('errorCat', 'log', 'msTimeout', 'runNow')
-    opts = pick(opts, fields)
     defaults(opts, {
       // default non-required user options
       errorCat: ErrorCat,
       runNow: true,
       // other options
       attempt: 0,
+      finalRetryFn: Promise.resolve(),
+      maxNumRetries: process.env.WORKER_MAX_NUM_RETRIES || 0,
       msTimeout: process.env.WORKER_TIMEOUT || 0,
       retryDelay: process.env.WORKER_MIN_RETRY_DELAY || 1
     })
@@ -85,16 +87,6 @@ class Worker {
     // put all opts on this
     Object.assign(this, opts)
     this.log.info({ queue: this.queue, job: this.job }, 'Worker created')
-
-    // Ensure that the `msTimeout` option is valid
-    this.msTimeout = parseInt(this.msTimeout, 10)
-    if (!isNumber(this.msTimeout)) {
-      throw new Error('Provided `msTimeout` is not an integer')
-    }
-
-    if (this.msTimeout < 0) {
-      throw new Error('Provided `msTimeout` is negative')
-    }
 
     if (this.runNow) {
       this.run()
@@ -184,6 +176,26 @@ class Worker {
       // If we encounter a fatal error we should no longer try to schedule
       // the job.
       return this.done()
+    })
+    .catch(() => {
+      // if maxNumRetries is set, call finalRetryFn and stop
+      if (this.maxNumRetries && this.attempt >= this.maxNumRetries) {
+        log.error({ attempt: this.attempt }, 'retry limit reached, trying handler')
+        return this.finalRetryFn()
+          .catch((finalErr) => {
+            log.warn({ err: finalErr }, 'final function errored')
+          })
+          .finally(() => {
+            const err = new WorkerError('final retry handler finished', {
+              queue: this.queue,
+              job: this.job,
+              attempt: this.attempt
+            })
+            log.error('final retry handler finished')
+            this._incMonitor('ponos.finish', { result: 'retry-error' })
+            this._reportError(err)
+          })
+      }
     })
     .catch((err) => {
       const attemptData = {

--- a/test/functional/retry-limit.js
+++ b/test/functional/retry-limit.js
@@ -53,7 +53,7 @@ describe('Basic Timeout Task', function () {
   }
 
   describe('with maxNumRetries', function () {
-    it('should fail twice and pass the third time', (done) => {
+    it('should fail 4 times and pass the fifth time', (done) => {
       testRecover = function (testJob) {
         try {
           assert.equal(job.message, testJob.message)

--- a/test/functional/retry-limit.js
+++ b/test/functional/retry-limit.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const chai = require('chai')
+const sinon = require('sinon')
+const Promise = require('bluebird')
+
+const assert = chai.assert
+
+// Ponos Tooling
+const ponos = require('../../src')
+const RabbitMQ = require('../../src/rabbitmq')
+
+// require the Worker class so we can verify the task is running
+const _Worker = require('../../src/worker')
+/*
+ *  In this example, we are going to have a job handler that times out at
+ *  decreasing intervals, throwing TimeoutErrors, until it passes.
+ */
+describe('Basic Timeout Task', function () {
+  let server
+  let rabbitmq
+  let testRecover
+  before(() => {
+    sinon.spy(_Worker.prototype, 'run')
+    rabbitmq = new RabbitMQ({})
+    const tasks = {
+      'ponos-test:one': {
+        task: () => {
+          return Promise.reject(new Error('death to all'))
+        },
+        finalRetryFn: (job) => {
+          return testRecover(job)
+        },
+        maxNumRetries: 5
+      }
+    }
+    server = new ponos.Server({ tasks: tasks })
+    return server.start()
+      .then(() => {
+        return rabbitmq.connect()
+      })
+  })
+  after(() => {
+    _Worker.prototype.run.restore()
+    return server.stop()
+      .then(() => {
+        return rabbitmq.disconnect()
+      })
+  })
+
+  const job = {
+    message: 'hello world'
+  }
+
+  describe('with maxNumRetries', function () {
+    it('should fail twice and pass the third time', (done) => {
+      testRecover = function (testJob) {
+        try {
+          assert.equal(job.message, testJob.message)
+          sinon.assert.callCount(_Worker.prototype.run, 5)
+        } catch (err) {
+          return done(err)
+        }
+        done()
+        return Promise.resolve()
+      }
+      rabbitmq.publishTask('ponos-test:one', job)
+    })
+  })
+})

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -330,6 +330,12 @@ describe('Server', () => {
       }, /must be a function/)
     })
 
+    it('should throw if the provided opts is not an object', () => {
+      assert.throws(() => {
+        server.setEvent(testQueue99, worker, 'not-an-object')
+      }, /must be a object/)
+    })
+
     it('should set default worker options', () => {
       server.setEvent(testQueue99, worker)
       assert.deepEqual(server._workerOptions[testQueue99], {})
@@ -354,6 +360,12 @@ describe('Server', () => {
       assert.throws(() => {
         server.setTask(testQueue99, 'not-a-function')
       }, /must be a function/)
+    })
+
+    it('should throw if the provided opts is not an object', () => {
+      assert.throws(() => {
+        server.setTask(testQueue99, worker, 'not-an-object')
+      }, /must be a object/)
     })
 
     it('should set default worker options', () => {

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -340,13 +340,6 @@ describe('Server', () => {
       server.setEvent(testQueue99, worker, opts)
       assert.deepEqual(server._workerOptions[testQueue99], opts)
     })
-
-    it('should pick only provided options that are valid', () => {
-      const opts = { msTimeout: 2000, foo: 'bar', not: 'athing' }
-      const expectedOpts = { msTimeout: 2000 }
-      server.setEvent(testQueue99, worker, opts)
-      assert.deepEqual(server._workerOptions[testQueue99], expectedOpts)
-    })
   })
 
   describe('setTask', () => {
@@ -372,13 +365,6 @@ describe('Server', () => {
       const opts = { msTimeout: 2000 }
       server.setTask(testQueue99, worker, opts)
       assert.deepEqual(server._workerOptions[testQueue99], opts)
-    })
-
-    it('should pick only provided options that are valid', () => {
-      const opts = { msTimeout: 2000, foo: 'bar', not: 'athing' }
-      const expectedOpts = { msTimeout: 2000 }
-      server.setTask(testQueue99, worker, opts)
-      assert.deepEqual(server._workerOptions[testQueue99], expectedOpts)
     })
   })
 


### PR DESCRIPTION
We realised we need a way to task fatal item in our queues so that we do not continuously kill our system. We also wanted hook so that we can write to a database in case of a service outage.

* added max retry param per job
* added max retry function to run after limit was reached
* added joi for input validation
* added flow type for joi
* updated test
* added new test