### PR TITLE
Add optional job validation

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -133,26 +133,22 @@ class Worker {
             timeout: this.msTimeout
           }
           log.info(attemptData, 'running task')
-          let taskPromise = Promise.try(() => {
-            if (this.jobSchema) {
-              return Promise
-                .try(() => {
-                  joi.assert(this.job, this.jobSchema)
-                })
-                .catch((err) => {
-                  throw new WorkerStopError('Invalid job', {
-                    queue: this.queue,
-                    job: this.job,
-                    validationErr: err
-                  })
-                })
-                .then(() => {
-                  return this.task(this.job)
-                })
-            } else {
+          let taskPromise = Promise
+            .try(() => {
+              if (this.jobSchema) {
+                joi.assert(this.job, this.jobSchema)
+              }
+            })
+            .catch((err) => {
+              throw new WorkerStopError('Invalid job', {
+                queue: this.queue,
+                job: this.job,
+                validationErr: err
+              })
+            })
+            .then(() => {
               return this.task(this.job)
-            }
-          })
+            })
 
           if (this.msTimeout) {
             taskPromise = taskPromise.timeout(this.msTimeout)

--- a/src/worker.js
+++ b/src/worker.js
@@ -143,7 +143,11 @@ class Worker {
                   joi.assert(this.job, this.jobSchema)
                 })
                 .catch(function (err) {
-                  throw new WorkerStopError('Invalid job', { err: err })
+                  throw new WorkerStopError('Invalid job', {
+                    queue: this.queue,
+                    job: this.job,
+                    validationErr: err
+                  })
                 })
                 .then(function () {
                   return this.task(this.job)

--- a/src/worker.js
+++ b/src/worker.js
@@ -83,11 +83,8 @@ class Worker {
       msTimeout: process.env.WORKER_TIMEOUT || 0,
       retryDelay: process.env.WORKER_MIN_RETRY_DELAY || 1
     })
-
     // managed required fields
     joi.assert(opts, optsSchema)
-    opts = joi.validate(opts, optsSchema, { stripUnknown: true }).value
-
     this.tid = opts.job.tid || uuid()
     opts.log = opts.log.child({ tid: this.tid, module: 'ponos:worker' })
     // put all opts on this
@@ -139,17 +136,17 @@ class Worker {
           let taskPromise = Promise.try(() => {
             if (this.jobSchema) {
               return Promise
-                .try(function validateArguments () {
+                .try(() => {
                   joi.assert(this.job, this.jobSchema)
                 })
-                .catch(function (err) {
+                .catch((err) => {
                   throw new WorkerStopError('Invalid job', {
                     queue: this.queue,
                     job: this.job,
                     validationErr: err
                   })
                 })
-                .then(function () {
+                .then(() => {
                   return this.task(this.job)
                 })
             } else {

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -71,6 +71,22 @@ describe('Worker', () => {
       }, /"log" is required/)
     })
 
+    it('should throw when jobSchema is not object', () => {
+      opts.jobSchema = 'no schema'
+      assert.throws(() => {
+        Worker.create(opts)
+      }, /"jobSchema" must be an object/)
+    })
+
+    it('should throw when jobSchema is not joi schema', () => {
+      opts.jobSchema = {
+        isJoi: false
+      }
+      assert.throws(() => {
+        Worker.create(opts)
+      }, /"isJoi" must be one of \[true\]/)
+    })
+
     it('should run the job if runNow is true (default)', () => {
       Worker.create(opts)
       sinon.assert.calledOnce(Worker.prototype.run)

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -3,6 +3,7 @@
 const assign = require('101/assign')
 const bunyan = require('bunyan')
 const chai = require('chai')
+const joi = require('joi')
 const monitor = require('monitor-dog')
 const noop = require('101/noop')
 const omit = require('101/omit')
@@ -25,6 +26,9 @@ describe('Worker', () => {
     opts = {
       queue: 'do.something.command',
       task: (data) => { return Promise.resolve(data).then(taskHandler) },
+      jobSchema: joi.object({
+        message: joi.string()
+      }),
       job: { message: 'hello world' },
       log: logger.child({ module: 'ponos:test' }),
       done: () => { return Promise.resolve().then(doneHandler) }


### PR DESCRIPTION
For each job it's possible to optionally specify joi `jobSchema`. Before running task we would validate job against schema and fail with `WorkerStopError` if needed.