### PR TITLE
add assert to publishers

### DIFF
--- a/interfaces/modules/joi.js.flow
+++ b/interfaces/modules/joi.js.flow
@@ -1,11 +1,13 @@
 declare class Joi<T> {
-  static func(): T;
-  static object(): T;
-  static string(): T;
-  static required(): T;
-  static number(): T;
-  static bool(): T;
+  static alternatives(): T;
+  static array(): T;
   static assert(opts: Object, schema: T): T;
+  static bool(): T;
+  static func(): T;
+  static number(): T;
+  static object(): T;
+  static required(): T;
+  static string(): T;
   static validate(opts: Object, schema: T, opts: Object): JoiValidate;
 }
 

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -159,26 +159,33 @@ class RabbitMQ {
         this.publishChannel.on('error', this._channelErrorHandler.bind(this))
       })
       .then(() => {
-        return Promise.each(this.events, (event) => {
-          if (typeof event === 'string') {
-            return this._assertExchange(event, 'fanout')
-          }
-
-          return this._assertExchange(event.name, 'fanout', event)
-        })
+        return this._assertQueuesAndExchanges()
       })
-      .then(() => {
-        return Promise.each(this.tasks, (task) => {
-          if (typeof task === 'string') {
-            return this._assertQueue(`${this.name}.${task}`)
-          }
-
-          return this._assertQueue(`${this.name}.${task.name}`, task)
-        })
-      })
-      .return()
   }
 
+  /**
+   * Asserts all passed queues and exchanges on channel
+   * @return {Promise} Promise resolved when everything is asserted
+   */
+  _assertQueuesAndExchanges (): Bluebird$Promise<void> {
+    return Promise.each(this.events, (event) => {
+      if (typeof event === 'string') {
+        return this._assertExchange(event, 'fanout')
+      }
+
+      return this._assertExchange(event.name, 'fanout', event)
+    })
+    .then(() => {
+      return Promise.each(this.tasks, (task) => {
+        if (typeof task === 'string') {
+          return this._assertQueue(`${this.name}.${task}`)
+        }
+
+        return this._assertQueue(`${this.name}.${task.name}`, task)
+      })
+    })
+    .return()
+  }
   /**
    * Takes an object representing a message and sends it to a queue.
    *

--- a/test/functional/basic.js
+++ b/test/functional/basic.js
@@ -13,16 +13,17 @@ const testWorkerEmitter = testWorker.emitter
 describe('Basic Example', () => {
   let server
   let rabbitmq
-
+  const testQueue = 'ponos-test:one'
   before(() => {
-    rabbitmq = new RabbitMQ({})
-    const tasks = {
-      'ponos-test:one': testWorker
-    }
+    const tasks = {}
+    tasks[testQueue] = testWorker
+    rabbitmq = new RabbitMQ({
+      tasks: Object.keys(tasks)
+    })
     server = new ponos.Server({ tasks: tasks })
-    return server.start()
+    return rabbitmq.connect()
       .then(() => {
-        return rabbitmq.connect()
+        return server.start()
       })
   })
 
@@ -42,6 +43,6 @@ describe('Basic Example', () => {
       eventName: 'task',
       message: 'hello world'
     }
-    rabbitmq.publishTask('ponos-test:one', job)
+    rabbitmq.publishTask(testQueue, job)
   })
 })

--- a/test/functional/failing.js
+++ b/test/functional/failing.js
@@ -27,10 +27,12 @@ describe('Basic Failing Task', () => {
   before(() => {
     sinon.spy(_Worker.prototype, 'run')
     sinon.spy(_Worker.prototype, '_reportError')
-    rabbitmq = new RabbitMQ({})
     const tasks = {
       'ponos-test:one': testWorker
     }
+    rabbitmq = new RabbitMQ({
+      tasks: Object.keys(tasks)
+    })
     server = new ponos.Server({ tasks: tasks })
     return server.start()
       .then(() => {

--- a/test/functional/retry-limit.js
+++ b/test/functional/retry-limit.js
@@ -22,7 +22,6 @@ describe('Basic Timeout Task', function () {
   let testRecover
   before(() => {
     sinon.spy(_Worker.prototype, 'run')
-    rabbitmq = new RabbitMQ({})
     const tasks = {
       'ponos-test:one': {
         task: () => {
@@ -34,6 +33,9 @@ describe('Basic Timeout Task', function () {
         maxNumRetries: 5
       }
     }
+    rabbitmq = new RabbitMQ({
+      tasks: Object.keys(tasks)
+    })
     server = new ponos.Server({ tasks: tasks })
     return server.start()
       .then(() => {

--- a/test/functional/tid.js
+++ b/test/functional/tid.js
@@ -12,10 +12,12 @@ describe('Basic Example', () => {
   let rabbitmq
 
   before(() => {
-    rabbitmq = new RabbitMQ({})
     const tasks = {
       'ponos-test:one': testWorker
     }
+    rabbitmq = new RabbitMQ({
+      tasks: Object.keys(tasks)
+    })
     server = new ponos.Server({ tasks: tasks })
     return server.start()
       .then(() => {

--- a/test/functional/timeout.js
+++ b/test/functional/timeout.js
@@ -28,10 +28,12 @@ describe('Basic Timeout Task', function () {
   before(() => {
     sinon.spy(_Worker.prototype, 'run')
     sinon.spy(_Bunyan.prototype, 'warn')
-    rabbitmq = new RabbitMQ({})
     const tasks = {
       'ponos-test:one': testWorker
     }
+    rabbitmq = new RabbitMQ({
+      tasks: Object.keys(tasks)
+    })
     server = new ponos.Server({ tasks: tasks })
     return server.start()
       .then(() => {

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -360,6 +360,7 @@ describe('rabbitmq', () => {
     const mockJob = { hello: 'world' }
 
     beforeEach(() => {
+      rabbitmq.tasks = [mockQueue]
       rabbitmq.publishChannel = {}
       rabbitmq.publishChannel.sendToQueue = sinon.stub().resolves()
       sinon.stub(RabbitMQ.prototype, '_validatePublish')
@@ -378,6 +379,13 @@ describe('rabbitmq', () => {
       )
     })
 
+    it('should reject if not defined', () => {
+      return assert.isRejected(
+        rabbitmq.publishTask('not-real', mockJob),
+        /Trying to publish task not defined in constructor/
+      )
+    })
+
     it('should publish with a buffer of the content', () => {
       const testContent = new Buffer(JSON.stringify(mockJob))
       RabbitMQ.prototype._validatePublish.returns(testContent)
@@ -386,7 +394,7 @@ describe('rabbitmq', () => {
           sinon.assert.calledOnce(rabbitmq.publishChannel.sendToQueue)
           sinon.assert.calledWithExactly(
             rabbitmq.publishChannel.sendToQueue,
-            mockQueue,
+            `test-client.${mockQueue}`,
             testContent
           )
           const contentCall = rabbitmq.publishChannel.sendToQueue.firstCall
@@ -402,6 +410,7 @@ describe('rabbitmq', () => {
     const mockJob = { hello: 'world' }
 
     beforeEach(() => {
+      rabbitmq.events = [mockExchange]
       rabbitmq.publishChannel = {}
       rabbitmq.publishChannel.publish = sinon.stub().resolves()
       sinon.stub(RabbitMQ.prototype, '_validatePublish').returns(true)
@@ -409,6 +418,13 @@ describe('rabbitmq', () => {
 
     afterEach(() => {
       RabbitMQ.prototype._validatePublish.restore()
+    })
+
+    it('should reject if not defined', () => {
+      return assert.isRejected(
+        rabbitmq.publishEvent('not-real', mockJob),
+        /Trying to publish event not defined in constructor/
+      )
     })
 
     it('should reject if _validatePublish throws', () => {

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -83,9 +83,7 @@ describe('Worker', () => {
     })
 
     it('should throw when jobSchema is not joi schema', () => {
-      opts.jobSchema = {
-        isJoi: false
-      }
+      opts.jobSchema = {}
       assert.throws(() => {
         Worker.create(opts)
       }, /"jobSchema" must be a Joi instance/)


### PR DESCRIPTION
* make publisher assert queue for tasks (subscribers should not know about publishers, it couples them)
* remove asserting task queue from subscribers
* make publisher assert exchange (publisher should setup its exchange, not subscriber)
* make event subscriber assert its queue to the exchange (publisher should not setup subscribers queue)
* update flow definitions
* add app name to tasks
* add joi schemas for tasks and queues