### PR TITLE
Add metadata

### DIFF
--- a/interfaces/modules/amqplib.js.flow
+++ b/interfaces/modules/amqplib.js.flow
@@ -16,8 +16,8 @@ declare class RabbitMQChannel {
   consume(queue: string, handler: Function): void;
   on(event: string, handler: Function): void;
   prefetch(count: Number, global?: Boolean): Bluebird$Promise<void>;
-  publish(exchange: string, routingKey: string, content: Buffer): Bluebird$Promise<void>;
-  sendToQueue(queue: string, content: Buffer): Bluebird$Promise<void>;
+  publish(exchange: string, routingKey: string, content: Buffer, opts: ?Object): Bluebird$Promise<void>;
+  sendToQueue(queue: string, content: Buffer, opts: ?Object): Bluebird$Promise<void>;
 }
 
 declare class RabbitMQConfirmChannel extends RabbitMQChannel {

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -569,9 +569,15 @@ describe('rabbitmq', () => {
           sinon.assert.calledWithExactly(
             rabbitmq.publishChannel.sendToQueue,
             `test-client.${mockQueue}`,
-            testContent
+            testContent,
+            {
+              headers: {
+                publisher: testName
+              }
+            }
           )
           const contentCall = rabbitmq.publishChannel.sendToQueue.firstCall
+          contentCall.args.pop()
           const content = contentCall.args.pop()
           assert.ok(Buffer.isBuffer(content))
           assert.equal(content.toString(), JSON.stringify(mockJob))
@@ -615,8 +621,15 @@ describe('rabbitmq', () => {
             rabbitmq.publishChannel.publish,
             mockExchange,
             '',
-            testContent
+            testContent,
+            {
+              headers:
+              {
+                publisher: testName
+              }
+            }
           )
+          rabbitmq.publishChannel.publish.firstCall.args.pop()
           const content = rabbitmq.publishChannel.publish.firstCall.args.pop()
           assert.ok(Buffer.isBuffer(content))
           assert.equal(content.toString(), JSON.stringify(mockJob))
@@ -1334,6 +1347,7 @@ describe('rabbitmq', () => {
         sinon.assert.calledWithExactly(
           mockHandler,
           { foo: 'bar' },
+          undefined,
           sinon.match.func
         )
       })

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -22,11 +22,15 @@ const tasks = {
     msTimeout: 4242
   }
 }
-function worker (job, done) {} // eslint-disable-line no-unused-vars
+function worker (job, headers, done) {} // eslint-disable-line no-unused-vars
 
 describe('Server', () => {
   let server
   let runStub
+  const testJobOpts = {
+    headers: { pubisher: 'Cedric' }
+  }
+
   beforeEach(() => {
     runStub = sinon.stub().resolves()
     sinon.stub(Worker, 'create').returns({
@@ -236,13 +240,14 @@ describe('Server', () => {
 
       it('should be created on subscribeToQueue', () => {
         const worker = RabbitMQ.prototype.subscribeToQueue.firstCall.args.pop()
-        worker(mockJob, mockDone)
+        worker(mockJob, testJobOpts, mockDone)
         sinon.assert.calledOnce(ponos.Server.prototype._enqueue)
         sinon.assert.calledWithExactly(
           ponos.Server.prototype._enqueue,
           'test-queue-01',
           sinon.match.func,
           mockJob,
+          testJobOpts,
           mockDone
         )
       })
@@ -250,13 +255,14 @@ describe('Server', () => {
       it('should be created on subscribeToFanoutExchange', () => {
         const worker = RabbitMQ.prototype.subscribeToFanoutExchange
           .firstCall.args.pop()
-        worker(mockJob, mockDone)
+        worker(mockJob, testJobOpts, mockDone)
         sinon.assert.calledOnce(ponos.Server.prototype._enqueue)
         sinon.assert.calledWithExactly(
           ponos.Server.prototype._enqueue,
           'test-queue-01',
           sinon.match.func,
           mockJob,
+          testJobOpts,
           mockDone
         )
       })
@@ -404,7 +410,7 @@ describe('Server', () => {
     })
 
     it('should provide the correct queue name', () => {
-      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, noop))
+      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, testJobOpts, noop))
         .then(() => {
           sinon.assert.calledOnce(Worker.create)
           sinon.assert.calledWithExactly(
@@ -416,7 +422,7 @@ describe('Server', () => {
 
     it('should provide the given job', () => {
       const job = { bar: 'baz' }
-      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, job, noop))
+      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, job, testJobOpts, noop))
         .then(() => {
           sinon.assert.calledWithExactly(
             Worker.create,
@@ -427,7 +433,7 @@ describe('Server', () => {
 
     it('should call done if worker rejected', () => {
       const stub = sinon.stub().rejects(new Error('Baggins'))
-      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, stub))
+      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, testJobOpts, stub))
         .then(() => {
           sinon.assert.calledOnce(stub)
         })
@@ -435,14 +441,14 @@ describe('Server', () => {
 
     it('should call done if worker resolved', () => {
       const stub = sinon.stub().resolves(new Error('Bombadil'))
-      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, stub))
+      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, testJobOpts, stub))
         .then(() => {
           sinon.assert.calledOnce(stub)
         })
     })
 
     it('should provide the correct task handler', () => {
-      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, noop))
+      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, testJobOpts, noop))
         .then(() => {
           sinon.assert.calledOnce(Worker.create)
           sinon.assert.calledWithExactly(
@@ -453,7 +459,7 @@ describe('Server', () => {
     })
 
     it('should provide the correct logger', () => {
-      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, noop))
+      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, testJobOpts, noop))
         .then(() => {
           sinon.assert.calledOnce(Worker.create)
           sinon.assert.calledWithExactly(
@@ -464,7 +470,7 @@ describe('Server', () => {
     })
 
     it('should provide the correct errorCat', () => {
-      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, noop))
+      assert.isFulfilled(server._runWorker('test-queue-01', taskHandler, { bar: 'baz' }, testJobOpts, noop))
         .then(() => {
           sinon.assert.calledOnce(Worker.create)
           sinon.assert.calledWithExactly(
@@ -475,7 +481,7 @@ describe('Server', () => {
     })
 
     it('should correctly provide custom worker options', () => {
-      assert.isFulfilled(server._runWorker('test-queue-02', taskHandler, { bar: 'baz' }, noop))
+      assert.isFulfilled(server._runWorker('test-queue-02', taskHandler, { bar: 'baz' }, testJobOpts, noop))
         .then(() => {
           sinon.assert.calledOnce(Worker.create)
           sinon.assert.calledWithExactly(
@@ -486,7 +492,7 @@ describe('Server', () => {
     })
 
     it('should call run on new worker', () => {
-      assert.isFulfilled(server._runWorker('test-queue-02', taskHandler, { bar: 'baz' }, noop))
+      assert.isFulfilled(server._runWorker('test-queue-02', taskHandler, { bar: 'baz' }, testJobOpts, noop))
         .then(() => {
           sinon.assert.calledOnce(runStub)
         })


### PR DESCRIPTION
Add headers to the jobs. Right now there is only one default header: 'publisher'. It shows who created job originally. Useful for debugging.
Also changed log levels in few places from trace to info.