### PR TITLE
Make opts schema flexible

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -33,7 +33,7 @@ const optsSchema = joi.object({
   retryDelay: joi.number().integer().min(0).required(),
   runNow: joi.bool(),
   task: joi.func().required()
-}).required()
+}).unknown()
 
 /**
  * Performs tasks for jobs on a given queue.


### PR DESCRIPTION
Sometimes we pass references to file as job definition. If the file has private functions (other than `task`) it will throw a validation error.
This PR fixes that.