### PR TITLE
Rename headers.publisher to appId

### DIFF
--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -272,9 +272,7 @@ class RabbitMQ {
       const queueName = `${this.name}.${queue}`
       const bufferContent = this._validatePublish(queue, content, 'tasks')
       const jobOpts = {
-        headers: {
-          publisher: this.name
-        }
+        appId: this.name
       }
       this.log.info({ queue: queueName, job: content, jobOpts: jobOpts }, 'Publishing task')
       this._incMonitor('task', queueName)
@@ -296,9 +294,7 @@ class RabbitMQ {
     return Promise.try(() => {
       const bufferContent = this._validatePublish(exchange, content, 'events')
       const jobOpts = {
-        headers: {
-          publisher: this.name
-        }
+        appId: this.name
       }
       this.log.info({ event: exchange, job: content, jobOpts: jobOpts }, 'Publishing event')
       // events do not need a routing key (so we send '')

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -1,5 +1,5 @@
 /* @flow */
-/* global Bluebird$Promise RabbitMQChannel RabbitMQConfirmChannel RabbitMQConnection SubscribeObject RabbitMQOptions QueueObject*/
+/* global Bluebird$Promise RabbitMQChannel RabbitMQConfirmChannel RabbitMQConnection SubscribeObject RabbitMQOptions QueueObject */
 'use strict'
 
 const amqplib = require('amqplib')

--- a/src/rate-limiters/redis.js
+++ b/src/rate-limiters/redis.js
@@ -1,5 +1,5 @@
 /* @flow */
-/* global Bluebird$Promise Logger RedisClient*/
+/* global Bluebird$Promise Logger RedisClient */
 'use strict'
 const joi = require('joi')
 const pick = require('101/pick')

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -574,9 +574,7 @@ describe('rabbitmq', () => {
             `test-client.${mockQueue}`,
             testContent,
             {
-              headers: {
-                publisher: testName
-              }
+              appId: testName
             }
           )
           const contentCall = rabbitmq.publishChannel.sendToQueue.firstCall
@@ -640,10 +638,7 @@ describe('rabbitmq', () => {
             '',
             testContent,
             {
-              headers:
-              {
-                publisher: testName
-              }
+              appId: testName
             }
           )
           rabbitmq.publishChannel.publish.firstCall.args.pop()


### PR DESCRIPTION
Fix #91
This seems to be correct way to set publisher.
We could use headers, but it seems like `appId` is just for that