### PR TITLE
Track origin event

### DIFF
--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -677,12 +677,10 @@ class RabbitMQ {
       timestamp: Date.now(),
       headers: {}
     }
+    const ns = getNamespace('ponos')
+    jobMeta.headers.previousEvent = ns && ns.get('previousEvent')
     // add tid to message if one does not exist
     if (!content.tid) {
-      const ns = getNamespace('ponos')
-      if (ns) {
-        jobMeta.headers.previousEvent = ns.get('previousEvent')
-      }
       const tid = ns && ns.get('tid')
       content.tid = tid || uuid()
     }

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -678,7 +678,7 @@ class RabbitMQ {
       headers: {}
     }
     const ns = getNamespace('ponos')
-    jobMeta.headers.previousEvent = ns && ns.get('previousEvent')
+    jobMeta.headers.previousEvent = ns && ns.get('currentWorkerName')
     // add tid to message if one does not exist
     if (!content.tid) {
       const tid = ns && ns.get('tid')

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -271,7 +271,7 @@ class RabbitMQ {
     return Promise.try(() => {
       const queueName = `${this.name}.${queue}`
       this._validatePublish(queue, content, 'tasks')
-      const payload = this._buildPayload(content)
+      const payload = RabbitMQ.buildPayload(content)
       this.log.info({ queue: queueName, job: content, jobMeta: payload.jobMeta }, 'Publishing task')
       this._incMonitor('task', queueName)
       return Promise.resolve(
@@ -291,7 +291,7 @@ class RabbitMQ {
   publishEvent (exchange: string, content: Object): Bluebird$Promise<void> {
     return Promise.try(() => {
       this._validatePublish(exchange, content, 'events')
-      const payload = this._buildPayload(content)
+      const payload = RabbitMQ.buildPayload(content)
       this.log.info({ event: exchange, job: content, jobMeta: payload.jobMeta }, 'Publishing event')
       // events do not need a routing key (so we send '')
       this._incMonitor('event', exchange)
@@ -671,10 +671,13 @@ class RabbitMQ {
    * @param {Object} content Content to send.
    * @return {Object} payload with `jobBuffer` and `jobMeta` props
    */
-  _buildPayload (content: Object) {
+  static buildPayload (content: Object) {
     // add tid to message if one does not exist
     if (!content.tid) {
       const ns = getNamespace('ponos')
+      if (ns) {
+        console.log('aaaaaaa', ns.get('originEvent'))
+      }
       const tid = ns && ns.get('tid')
       content.tid = tid || uuid()
     }

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -675,9 +675,9 @@ class RabbitMQ {
     // add tid to message if one does not exist
     if (!content.tid) {
       const ns = getNamespace('ponos')
-      if (ns) {
-        console.log('aaaaaaa', ns.get('originEvent'))
-      }
+      // if (ns) {
+      //   console.log('aaaaaaa', ns.get('originEvent'))
+      // }
       const tid = ns && ns.get('tid')
       content.tid = tid || uuid()
     }

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -672,21 +672,22 @@ class RabbitMQ {
    * @return {Object} payload with `jobBuffer` and `jobMeta` props
    */
   static buildPayload (content: Object) {
+    const jobMeta = {
+      appId: this.name,
+      timestamp: Date.now(),
+      headers: {}
+    }
     // add tid to message if one does not exist
     if (!content.tid) {
       const ns = getNamespace('ponos')
-      // if (ns) {
-      //   console.log('aaaaaaa', ns.get('originEvent'))
-      // }
+      if (ns) {
+        jobMeta.headers.previousEvent = ns.get('previousEvent')
+      }
       const tid = ns && ns.get('tid')
       content.tid = tid || uuid()
     }
     const stringContent = JSON.stringify(content)
     const jobBuffer = new Buffer(stringContent)
-    const jobMeta = {
-      appId: this.name,
-      timestamp: Date.now()
-    }
     return {
       jobBuffer: jobBuffer,
       jobMeta: jobMeta

--- a/src/rabbitmq.js
+++ b/src/rabbitmq.js
@@ -686,7 +686,7 @@ class RabbitMQ {
       timestamp: Date.now(),
       headers: {}
     }
-    jobMeta.headers.previousEvent = RabbitMQ.getKeyFromClsNamespace('currentWorkerName')
+    jobMeta.headers.publisherWorkerName = RabbitMQ.getKeyFromClsNamespace('currentWorkerName')
     return jobMeta
   }
   /**

--- a/src/worker.js
+++ b/src/worker.js
@@ -133,7 +133,7 @@ class Worker {
     return Promise.fromCallback((cb) => {
       cls.run(() => {
         cls.set('tid', this.tid)
-        cls.set('previousEvent', this.queue)
+        cls.set('currentWorkerName', this.queue)
         Promise.try(() => {
           this.log.info({
             attempt: this.attempt++,

--- a/src/worker.js
+++ b/src/worker.js
@@ -133,7 +133,7 @@ class Worker {
     return Promise.fromCallback((cb) => {
       cls.run(() => {
         cls.set('tid', this.tid)
-        cls.set('originEvent', this.queue)
+        // cls.set('originEvent', this.queue)
         Promise.try(() => {
           this.log.info({
             attempt: this.attempt++,

--- a/src/worker.js
+++ b/src/worker.js
@@ -133,7 +133,7 @@ class Worker {
     return Promise.fromCallback((cb) => {
       cls.run(() => {
         cls.set('tid', this.tid)
-        // cls.set('originEvent', this.queue)
+        cls.set('previousEvent', this.queue)
         Promise.try(() => {
           this.log.info({
             attempt: this.attempt++,

--- a/src/worker.js
+++ b/src/worker.js
@@ -133,6 +133,7 @@ class Worker {
     return Promise.fromCallback((cb) => {
       cls.run(() => {
         cls.set('tid', this.tid)
+        cls.set('originEvent', this.queue)
         Promise.try(() => {
           this.log.info({
             attempt: this.attempt++,

--- a/test/functional/basic.js
+++ b/test/functional/basic.js
@@ -7,23 +7,31 @@ const assert = chai.assert
 // Ponos Tooling
 const ponos = require('../../src')
 const RabbitMQ = require('../../src/rabbitmq')
-const testWorker = require('./fixtures/worker')
-const testWorkerEmitter = testWorker.emitter
+const basicWorker = require('./fixtures/worker')
+const basicWorkerTwoEmitter = basicWorker.emitter
+const testWorkerOne = require('./fixtures/worker-one')
+const testWorkerTwo = require('./fixtures/worker-two')
+const testWorkerTwoEmitter = testWorkerTwo.emitter
 
 describe('Basic Example', () => {
   let server
   let rabbitmq
-  const testQueue = 'ponos-test:one'
+  const testQueueBasic = 'ponos-test:zero'
+  const testQueueOne = 'ponos-test:one'
+  const testQueueTwo = 'ponos-test:two'
   before(() => {
     const tasks = {}
-    tasks[testQueue] = testWorker
     rabbitmq = new RabbitMQ({
       name: 'ponos.test',
-      tasks: Object.keys(tasks)
+      tasks: [ testQueueBasic, testQueueOne, testQueueTwo ]
     })
+    tasks[testQueueBasic] = basicWorker
+    tasks[testQueueOne] = testWorkerOne
+    tasks[testQueueTwo] = testWorkerTwo
     server = new ponos.Server({ name: 'ponos.test', tasks: tasks })
     return rabbitmq.connect()
       .then(() => {
+        testWorkerOne.setPublisher(rabbitmq)
         return server.start()
       })
   })
@@ -36,14 +44,27 @@ describe('Basic Example', () => {
   })
 
   it('should queue a task that triggers an event', (done) => {
-    testWorkerEmitter.on('task', function (data, jobMeta) {
-      assert.equal(data.data, 'hello world')
+    basicWorkerTwoEmitter.on('task', function (job, jobMeta) {
+      assert.equal(job.message, 'hello world')
       done()
     })
     const job = {
       eventName: 'task',
       message: 'hello world'
     }
-    rabbitmq.publishTask(testQueue, job)
+    rabbitmq.publishTask(testQueueBasic, job)
+  })
+
+  it('should trigger series of events', (done) => {
+    testWorkerTwoEmitter.on('task', function (job, jobMeta) {
+      assert.equal(jobMeta.headers.previousEvent, testQueueOne)
+      assert.equal(job.message, 'hello world2')
+      done()
+    })
+    const job = {
+      eventName: 'task',
+      message: 'hello world'
+    }
+    rabbitmq.publishTask(testQueueOne, job)
   })
 })

--- a/test/functional/basic.js
+++ b/test/functional/basic.js
@@ -57,7 +57,7 @@ describe('Basic Example', () => {
 
   it('should trigger series of events', (done) => {
     testWorkerTwoEmitter.on('task', function (job, jobMeta) {
-      assert.equal(jobMeta.headers.previousEvent, testQueueOne)
+      assert.equal(jobMeta.headers.publisherWorkerName, testQueueOne)
       assert.equal(job.message, 'hello world2')
       done()
     })

--- a/test/functional/fixtures/worker-one.js
+++ b/test/functional/fixtures/worker-one.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const EventEmitter = require('events')
+const Promise = require('bluebird')
+const WorkerStopError = require('error-cat/errors/worker-stop-error')
+
+let rabbitmq
+/**
+ * A simple worker that will publish a message to a queue.
+ * @param {object} job Object describing the job.
+ * @param {string} job.queue Queue on which the message will be published.
+ * @returns {promise} Resolved when the message is put on the queue.
+ */
+module.exports = (job, jobMeta) => {
+  return Promise.resolve()
+    .then(() => {
+      if (!job.eventName) {
+        throw new WorkerStopError('eventName is required')
+      }
+      if (!job.message) {
+        throw new WorkerStopError('fail test message is required')
+      }
+    })
+    .then(() => {
+      const job = {
+        eventName: 'task',
+        message: 'hello world2'
+      }
+      rabbitmq.publishTask('ponos-test:two', job)
+      module.exports.emitter.emit(job.eventName, job, jobMeta)
+    })
+}
+
+module.exports.setPublisher = (publisher) => {
+  rabbitmq = publisher
+}
+
+module.exports.emitter = new EventEmitter()

--- a/test/functional/fixtures/worker-tid.js
+++ b/test/functional/fixtures/worker-tid.js
@@ -4,9 +4,12 @@ const EventEmitter = require('events')
 const Promise = require('bluebird')
 const getNamespace = require('continuation-local-storage').getNamespace
 
-const testTid = (step) => {
+const testClsData = (step) => {
   if (typeof getNamespace('ponos').get('tid') !== 'string') {
     throw new Error('tid not found after Promise.' + step)
+  }
+  if (getNamespace('ponos').get('previousEvent') !== 'ponos-test:one') {
+    throw new Error('previousEvent not found after Promise.' + step)
   }
 }
 
@@ -19,164 +22,164 @@ const testTid = (step) => {
 module.exports = (job) => {
   return Promise
     .try(() => {
-      testTid('try')
+      testClsData('try')
       return Promise.try(() => {
-        testTid('try.try')
+        testClsData('try.try')
       }).then(() => {
-        testTid('try.then')
+        testClsData('try.then')
       })
       .then(() => {
         return Promise.resolve()
           .then(() => {
-            testTid('try.then.resolve.then')
+            testClsData('try.then.resolve.then')
           })
       })
     })
     .then(() => {
-      testTid('then')
+      testClsData('then')
       return [1, 2, 3]
     })
     .spread((a, b, c) => {
-      testTid('spread')
+      testClsData('spread')
       return [1, 2, 3]
     })
     .then(() => {
-      testTid('then after spread')
+      testClsData('then after spread')
       throw new Error('test')
     })
     .catch(() => {
-      testTid('catch')
+      testClsData('catch')
     })
     .then(() => {
-      testTid('then after catch')
+      testClsData('then after catch')
     })
     .finally(() => {
-      testTid('finally')
+      testClsData('finally')
     })
     .then(() => {
-      testTid('then after finally')
+      testClsData('then after finally')
     })
     .then(() => {
       return Promise.resolve().then(() => {
-        testTid('then.resolve.then.bind')
+        testClsData('then.resolve.then.bind')
       })
       .bind(this)
       .then(() => {
-        testTid('then.resolve.then.bind.then')
+        testClsData('then.resolve.then.bind.then')
       })
     })
     .then(() => {
       return Promise.reject(new Error('test')).catch(() => {
-        testTid('then.resolve.reject.catch')
+        testClsData('then.resolve.reject.catch')
       })
     })
     .then(() => {
       return Promise.all([
-        Promise.resolve().then(() => { testTid('then.all.resolve.then') }),
-        Promise.try(() => { testTid('then.all.try') })
+        Promise.resolve().then(() => { testClsData('then.all.resolve.then') }),
+        Promise.try(() => { testClsData('then.all.try') })
       ])
       .then(() => {
-        testTid('then after all')
+        testClsData('then after all')
       })
     })
     .then(() => {
       return Promise.props({
-        a: Promise.resolve().then(() => { testTid('then.props.resolve.then') }),
-        b: Promise.try(() => { testTid('then.props.try') })
+        a: Promise.resolve().then(() => { testClsData('then.props.resolve.then') }),
+        b: Promise.try(() => { testClsData('then.props.try') })
       })
       .then(() => {
-        testTid('then after props')
+        testClsData('then after props')
       })
     })
     .then(() => {
       return Promise.any([
-        Promise.resolve().then(() => { testTid('then.any.resolve.then') }),
-        Promise.try(() => { testTid('then.any.try') })
+        Promise.resolve().then(() => { testClsData('then.any.resolve.then') }),
+        Promise.try(() => { testClsData('then.any.try') })
       ])
       .then(() => {
-        testTid('then after any')
+        testClsData('then after any')
       })
     })
     .then(() => {
       return Promise.some([
-        Promise.resolve().then(() => { testTid('then.some.resolve.then') }),
-        Promise.try(() => { testTid('then.some.try') })
+        Promise.resolve().then(() => { testClsData('then.some.resolve.then') }),
+        Promise.try(() => { testClsData('then.some.try') })
       ], 2)
       .then(() => {
-        testTid('then after some')
+        testClsData('then after some')
       })
     })
     .then(() => {
       return Promise.map([1, 2], () => {
-        testTid('then.map')
+        testClsData('then.map')
       })
       .then(() => {
-        testTid('then after map')
+        testClsData('then after map')
       })
     })
     .then(() => {
       return Promise.reduce([1, 2], () => {
-        testTid('then.reduce')
+        testClsData('then.reduce')
       })
       .then(() => {
-        testTid('then after reduce')
+        testClsData('then after reduce')
       })
     })
     .then(() => {
       return Promise.filter([1, 2], () => {
-        testTid('then.filter')
+        testClsData('then.filter')
       })
       .then(() => {
-        testTid('then after filter')
+        testClsData('then after filter')
       })
     })
     .then(() => {
       return Promise.each([1, 2], () => {
-        testTid('then.each')
+        testClsData('then.each')
       })
       .then(() => {
-        testTid('then after each')
+        testClsData('then after each')
       })
     })
     .then(() => {
       return Promise.mapSeries([1, 2], () => {
-        testTid('then.mapSeries')
+        testClsData('then.mapSeries')
       })
       .then(() => {
-        testTid('then after mapSeries')
+        testClsData('then after mapSeries')
       })
     })
     .then(() => {
       return Promise.race([
-        Promise.resolve().then(() => { testTid('then.race.resolve.then') }),
-        Promise.try(() => { testTid('then.race.try') })
+        Promise.resolve().then(() => { testClsData('then.race.resolve.then') }),
+        Promise.try(() => { testClsData('then.race.try') })
       ])
       .then(() => {
-        testTid('then after race')
+        testClsData('then after race')
       })
     })
     .then(() => {
       return Promise.using(() => {
         return Promise.resolve().disposer(() => {
-          testTid('then.using.resolve.disposer')
+          testClsData('then.using.resolve.disposer')
         })
       }, () => {
-        return Promise.try(() => { testTid('then.using.try') })
+        return Promise.try(() => { testClsData('then.using.try') })
       })
       .then(() => {
-        testTid('then after using')
+        testClsData('then after using')
       })
     })
     .then(() => {
       const testFuncs = {
         sync: (cb) => {
-          testTid('promisify.sync')
+          testClsData('promisify.sync')
           cb()
         },
         cb: (cb) => {
-          testTid('promisify.cb')
+          testClsData('promisify.cb')
           setTimeout(() => {
-            testTid('promisify.cb.setTimeout')
+            testClsData('promisify.cb.setTimeout')
             cb()
           })
         }
@@ -185,19 +188,19 @@ module.exports = (job) => {
       const cbA = Promise.promisify(testFuncs.cb)
       return Promise.all([syncA(), cbA()])
         .then(() => {
-          testTid('then.promisify.all.then')
+          testClsData('then.promisify.all.then')
         })
     })
     .then(() => {
       const testFuncs = {
         sync: (cb) => {
-          testTid('promisifyAll.sync')
+          testClsData('promisifyAll.sync')
           cb()
         },
         cb: (cb) => {
-          testTid('promisifyAll.cb')
+          testClsData('promisifyAll.cb')
           setTimeout(() => {
-            testTid('promisifyAll.cb.setTimeout')
+            testClsData('promisifyAll.cb.setTimeout')
             cb()
           }, 10)
         }
@@ -205,62 +208,62 @@ module.exports = (job) => {
       Promise.promisifyAll(testFuncs)
       return Promise.all([testFuncs.syncAsync(), testFuncs.cbAsync()])
         .then(() => {
-          testTid('then.promisifyAll.all.then')
+          testClsData('then.promisifyAll.all.then')
         })
     })
     .then(() => {
       const testFuncs = {
         sync: (cb) => {
-          testTid('fromCallback.sync')
+          testClsData('fromCallback.sync')
           cb()
         },
         cb: (cb) => {
-          testTid('fromCallback.cb')
+          testClsData('fromCallback.cb')
           setTimeout(() => {
-            testTid('fromCallback.cb.setTimeout')
+            testClsData('fromCallback.cb.setTimeout')
             cb()
           })
         }
       }
       return Promise.all([Promise.fromCallback((cb) => {
-        testTid('then.all.fromCallback.sync')
+        testClsData('then.all.fromCallback.sync')
         testFuncs.sync(cb)
       }), Promise.fromCallback((cb) => {
-        testTid('then.all.fromCallback.cb')
+        testClsData('then.all.fromCallback.cb')
         testFuncs.cb(cb)
       })])
       .then(() => {
-        testTid('then.fromCallback.all.then')
+        testClsData('then.fromCallback.all.then')
       })
     })
     .then(() => {
       return Promise.fromCallback((cb) => {
-        testTid('then.fromCallback')
+        testClsData('then.fromCallback')
         return Promise.resolve().asCallback(() => {
-          testTid('then.asCallback')
+          testClsData('then.asCallback')
           cb()
         })
       })
       .then(() => {
-        testTid('then after asCallback')
+        testClsData('then after asCallback')
       })
     })
     .then(() => {
       return Promise.delay(1)
         .then(() => {
-          testTid('then after delay')
+          testClsData('then after delay')
         })
     })
     .then(() => {
       return Promise.delay(100).timeout(10).catch(Promise.TimeoutError, () => {
-        testTid('then.TimeoutError')
+        testClsData('then.TimeoutError')
       })
       .then(() => {
-        testTid('then after timeout')
+        testClsData('then after timeout')
       })
     })
     .tap(() => {
-      testTid('tap')
+      testClsData('tap')
     })
     .then(() => {
       module.exports.emitter.emit('passed')

--- a/test/functional/fixtures/worker-tid.js
+++ b/test/functional/fixtures/worker-tid.js
@@ -8,8 +8,8 @@ const testClsData = (step) => {
   if (typeof getNamespace('ponos').get('tid') !== 'string') {
     throw new Error('tid not found after Promise.' + step)
   }
-  if (getNamespace('ponos').get('previousEvent') !== 'ponos-test:one') {
-    throw new Error('previousEvent not found after Promise.' + step)
+  if (getNamespace('ponos').get('currentWorkerName') !== 'ponos-test:one') {
+    throw new Error('currentWorkerName not found after Promise.' + step)
   }
 }
 

--- a/test/functional/fixtures/worker-two.js
+++ b/test/functional/fixtures/worker-two.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const EventEmitter = require('events')
+const Promise = require('bluebird')
+const WorkerStopError = require('error-cat/errors/worker-stop-error')
+
+/**
+ * A simple worker that will publish a message to a queue.
+ * @param {object} job Object describing the job.
+ * @param {string} job.queue Queue on which the message will be published.
+ * @returns {promise} Resolved when the message is put on the queue.
+ */
+module.exports = (job, jobMeta) => {
+  return Promise.resolve()
+    .then(() => {
+      if (!job.eventName) {
+        throw new WorkerStopError('eventName is required')
+      }
+      if (!job.message) {
+        throw new WorkerStopError('fail test message is required')
+      }
+    })
+    .then(() => {
+      module.exports.emitter.emit(job.eventName, job, jobMeta)
+    })
+}
+
+module.exports.emitter = new EventEmitter()

--- a/test/functional/fixtures/worker.js
+++ b/test/functional/fixtures/worker.js
@@ -21,8 +21,7 @@ module.exports = (job, jobMeta) => {
       }
     })
     .then(() => {
-      module.exports.emitter.emit(job.eventName, { data: job.message }, jobMeta)
+      module.exports.emitter.emit(job.eventName, job, jobMeta)
     })
 }
-
 module.exports.emitter = new EventEmitter()

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -845,6 +845,15 @@ describe('rabbitmq', () => {
         rabbitmq._validatePublish('test', { b: 1 }, 'events')
       }, Error, /"a" is required/)
     })
+
+    it('should return if jobSchema is not defined', function () {
+      const mockJob = {
+        name: 'test'
+      }
+      rabbitmq.events = [mockJob]
+      const result = rabbitmq._validatePublish('test', { b: 1 }, 'events')
+      assert.isUndefined(result)
+    })
   }) // end _validatePublish
 
   describe('_connectionErrorHandler', () => {

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -760,6 +760,12 @@ describe('rabbitmq', () => {
         })
       })
     })
+
+    it('should not set previousEvent if namespace does not exist', () => {
+      const payload = RabbitMQ.buildPayload({})
+      assert.isUndefined(payload.jobMeta.headers.previousEvent)
+    })
+
     describe('stringify error', function () {
       beforeEach(() => {
         sinon.stub(JSON, 'stringify').throws(new Error('custom json error'))

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -747,13 +747,13 @@ describe('rabbitmq', () => {
       })
     })
 
-    it('should use previousEvent if in namespace', () => {
+    it('should use currentWorkerName if in namespace', () => {
       const testEvent = 'app.started'
       const ns = cls.createNamespace('ponos')
 
       return Promise.fromCallback((cb) => {
         ns.run(() => {
-          ns.set('previousEvent', testEvent)
+          ns.set('currentWorkerName', testEvent)
           const payload = RabbitMQ.buildPayload({})
           assert.isString(payload.jobMeta.headers.previousEvent, testEvent)
           cb()

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -746,6 +746,20 @@ describe('rabbitmq', () => {
         })
       })
     })
+
+    it('should use previousEvent if in namespace', () => {
+      const testEvent = 'app.started'
+      const ns = cls.createNamespace('ponos')
+
+      return Promise.fromCallback((cb) => {
+        ns.run(() => {
+          ns.set('previousEvent', testEvent)
+          const payload = RabbitMQ.buildPayload({})
+          assert.isString(payload.jobMeta.headers.previousEvent, testEvent)
+          cb()
+        })
+      })
+    })
     describe('stringify error', function () {
       beforeEach(() => {
         sinon.stub(JSON, 'stringify').throws(new Error('custom json error'))

--- a/test/unit/rabbitmq.js
+++ b/test/unit/rabbitmq.js
@@ -773,15 +773,15 @@ describe('rabbitmq', () => {
         ns.run(() => {
           ns.set('currentWorkerName', testEvent)
           const jobMeta = RabbitMQ.buildJobMeta('api')
-          assert.isString(jobMeta.headers.previousEvent, testEvent)
+          assert.isString(jobMeta.headers.publisherWorkerName, testEvent)
           cb()
         })
       })
     })
 
-    it('should not set previousEvent if namespace does not exist', () => {
+    it('should not set publisherWorkerName if namespace does not exist', () => {
       const jobMeta = RabbitMQ.buildJobMeta('api')
-      assert.isUndefined(jobMeta.headers.previousEvent)
+      assert.isUndefined(jobMeta.headers.publisherWorkerName)
     })
   })
 


### PR DESCRIPTION
`jobMeta` now has `headers.previousEvent` with name of the event that triggered current event.