### PR TITLE
Add global error events

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "chai-as-promised": "^6.0.0",
     "coveralls": "^2.11.4",
     "eslint-config-standard": "^6.2.0",
-    "flow-bin": "^0.32.0",
+    "flow-bin": "^0.33.0",
     "github-changes": "^1.0.0",
     "in-publish": "^2.0.0",
     "istanbul": "^1.0.0-alpha.2",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "chai": "^3.3.0",
     "chai-as-promised": "^6.0.0",
     "coveralls": "^2.11.4",
-    "eslint-config-standard": "^5.3.5",
+    "eslint-config-standard": "^6.2.0",
     "flow-bin": "^0.32.0",
     "github-changes": "^1.0.0",
     "in-publish": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
   ],
   "author": "Ryan Sandor Richards <sandor.richards@gmail.com>",
   "contributors": [
-    "Anandkumar patel <anand@runnable.com>",
-    "Bryan Kendall <bryan@runnable.com>"
+    "Anandkumar Patel <anand@runnable.com>",
+    "Bryan Kendall <bryan@runnable.com>",
+    "Anton Podviaznikov <anton@podviaznikov.com>"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/server.js
+++ b/src/server.js
@@ -96,7 +96,7 @@ class Server {
     )
     this._rabbitmq = new RabbitMQ(rabbitmqOpts)
     if (this._opts.enableErrorEvents) {
-      const errorPublisherAppName = this._opts.name ? this._opts.name + '.error.errorPublisher' : 'ponos.error.errorPublisher'
+      const errorPublisherAppName = this._opts.name ? this._opts.name + '.error.publisher' : 'ponos.error.publisher'
       const rabbitmqPublisherOpts = defaults(
         this._opts.rabbitmq || {},
         {

--- a/src/worker.js
+++ b/src/worker.js
@@ -249,7 +249,7 @@ class Worker {
       const erroredJob = {
         originalJobPayload: this.job,
         originalJobMeta: this.jobMeta,
-        originalTaskName: this.queue,
+        originalWorkerName: this.queue,
         error: err
       }
       this.errorPublisher.publishEvent('worker.errored', erroredJob)

--- a/src/worker.js
+++ b/src/worker.js
@@ -21,7 +21,7 @@ clsBlueBird(cls)
 const optsSchema = joi.object({
   attempt: joi.number().integer().min(0).required(),
   errorCat: joi.object(),
-  publisher: joi.object(),
+  errorPublisher: joi.object(),
   finalRetryFn: joi.func(),
   jobSchema: joi.object({
     isJoi: joi.bool().valid(true)
@@ -57,7 +57,7 @@ const optsSchema = joi.object({
 class Worker {
   attempt: number;
   errorCat: ErrorCat;
-  publisher: RabbitMQ;
+  errorPublisher: RabbitMQ;
   finalRetryFn: Function;
   jobSchema: Object;
   job: Object;
@@ -245,14 +245,14 @@ class Worker {
     this.log.error({ err: err }, 'Worker task fatally errored')
     this._incMonitor('ponos.finish-error', { result: 'fatal-error' })
     this._incMonitor('ponos.finish', { result: 'fatal-error' })
-    if (this.publisher) {
+    if (this.errorPublisher) {
       const erroredJob = {
         originalJobPayload: this.job,
         originalJobMeta: this.jobMeta,
         originalTaskName: this.queue,
         error: err
       }
-      this.publisher.publishEvent('worker.errored', erroredJob)
+      this.errorPublisher.publishEvent('worker.errored', erroredJob)
     }
   }
 

--- a/test/functional/fixtures/worker-one.js
+++ b/test/functional/fixtures/worker-one.js
@@ -34,5 +34,4 @@ module.exports = (job, jobMeta) => {
 module.exports.setPublisher = (publisher) => {
   rabbitmq = publisher
 }
-
 module.exports.emitter = new EventEmitter()

--- a/test/functional/fixtures/worker-two.js
+++ b/test/functional/fixtures/worker-two.js
@@ -24,5 +24,4 @@ module.exports = (job, jobMeta) => {
       module.exports.emitter.emit(job.eventName, job, jobMeta)
     })
 }
-
 module.exports.emitter = new EventEmitter()

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -102,6 +102,23 @@ describe('Server', () => {
       })
       assert.ok(s)
       assert.instanceOf(s.errorPublisher, RabbitMQ)
+      assert.equal(s.errorPublisher.name, 'ponos.error.publisher')
+      assert.equal(s.errorPublisher.events.length, 1)
+      assert.equal(s.errorPublisher.events[0].name, 'worker.errored')
+      assert.isNotNull(s.errorPublisher.events[0].jobSchema)
+    })
+
+    it('should set errorPublisher name depending on name opt', () => {
+      const s = new ponos.Server({
+        enableErrorEvents: true,
+        name: 'api'
+      })
+      assert.ok(s)
+      assert.instanceOf(s.errorPublisher, RabbitMQ)
+      assert.equal(s.errorPublisher.name, 'api.error.publisher')
+      assert.equal(s.errorPublisher.events.length, 1)
+      assert.equal(s.errorPublisher.events[0].name, 'worker.errored')
+      assert.isNotNull(s.errorPublisher.events[0].jobSchema)
     })
 
     it('should not have errorPublisher if option not passed', () => {

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -96,6 +96,20 @@ describe('Server', () => {
       assert.isUndefined(s._redisRateLimiter)
     })
 
+    it('should create errorPublisher if options passed', () => {
+      const s = new ponos.Server({
+        enableErrorEvents: true
+      })
+      assert.ok(s)
+      assert.instanceOf(s.errorPublisher, RabbitMQ)
+    })
+
+    it('should not have errorPublisher if option not passed', () => {
+      const s = new ponos.Server()
+      assert.ok(s)
+      assert.isUndefined(s.errorPublisher)
+    })
+
     it('should not call setAllTasks if they were not provided', () => {
       const s = new ponos.Server()
       assert.ok(s)

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -713,15 +713,20 @@ describe('Server', () => {
   })
 
   describe('start', () => {
+    let errorPublisher
     beforeEach(() => {
       sinon.stub(RabbitMQ.prototype, 'connect').resolves()
       sinon.stub(RedisRateLimiter.prototype, 'connect').resolves()
       sinon.stub(ponos.Server.prototype, '_subscribeAll').resolves()
       sinon.stub(ponos.Server.prototype, 'consume').resolves()
       sinon.stub(errorCat, 'report').returns()
+      errorPublisher = new RabbitMQ({
+        name: 'api'
+      })
     })
 
     afterEach(() => {
+      server.errorPublisher = null
       RabbitMQ.prototype.connect.restore()
       RedisRateLimiter.prototype.connect.restore()
       ponos.Server.prototype._subscribeAll.restore()
@@ -733,6 +738,14 @@ describe('Server', () => {
       return assert.isFulfilled(server.start())
         .then(() => {
           sinon.assert.calledOnce(RabbitMQ.prototype.connect)
+        })
+    })
+
+    it('should connect to errorPublisher if exists', () => {
+      server.errorPublisher = errorPublisher
+      return assert.isFulfilled(server.start())
+        .then(() => {
+          sinon.assert.calledTwice(RabbitMQ.prototype.connect)
         })
     })
 
@@ -764,15 +777,20 @@ describe('Server', () => {
 
   describe('stop', () => {
     let server
+    let errorPublisher
 
     beforeEach(() => {
       server = new ponos.Server({ tasks: tasks })
+      errorPublisher = new RabbitMQ({
+        name: 'api'
+      })
       sinon.stub(RabbitMQ.prototype, 'unsubscribe').resolves()
       sinon.stub(RabbitMQ.prototype, 'disconnect').resolves()
       sinon.stub(errorCat, 'report')
     })
 
     afterEach(() => {
+      server.errorPublisher = null
       RabbitMQ.prototype.unsubscribe.restore()
       RabbitMQ.prototype.disconnect.restore()
       errorCat.report.restore()
@@ -789,6 +807,14 @@ describe('Server', () => {
       return assert.isFulfilled(server.stop())
         .then(() => {
           sinon.assert.calledOnce(RabbitMQ.prototype.disconnect)
+        })
+    })
+
+    it('should close errorPublisher connection if exists', () => {
+      server.errorPublisher = errorPublisher
+      return assert.isFulfilled(server.stop())
+        .then(() => {
+          sinon.assert.calledTwice(RabbitMQ.prototype.disconnect)
         })
     })
 

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -7,6 +7,7 @@ const noop = require('101/noop')
 const omit = require('101/omit')
 const Promise = require('bluebird')
 const sinon = require('sinon')
+const RabbitMQ = require('../../src/rabbitmq')
 const WorkerStopError = require('error-cat/errors/worker-stop-error')
 const assert = chai.assert
 const TimeoutError = Promise.TimeoutError
@@ -627,6 +628,10 @@ describe('Worker', () => {
     describe('_handleWorkerStopError', () => {
       beforeEach(() => {
         sinon.stub(worker, '_incMonitor')
+        sinon.stub(RabbitMQ.prototype, 'publishEvent')
+      })
+      afterEach(() => {
+        RabbitMQ.prototype.publishEvent.restore()
       })
 
       it('should monitor error', () => {
@@ -634,6 +639,21 @@ describe('Worker', () => {
         sinon.assert.calledTwice(worker._incMonitor)
         sinon.assert.calledWith(worker._incMonitor, 'ponos.finish-error', { result: 'fatal-error' })
         sinon.assert.calledWith(worker._incMonitor, 'ponos.finish', { result: 'fatal-error' })
+        sinon.assert.notCalled(RabbitMQ.prototype.publishEvent)
+      })
+
+      it('should call errorPublisher.publishEvent', () => {
+        worker.errorPublisher = new RabbitMQ({})
+        const error = new Error('Failed')
+        worker._handleWorkerStopError(error)
+        sinon.assert.calledOnce(RabbitMQ.prototype.publishEvent)
+        const erroredJob = {
+          originalJobPayload: worker.job,
+          originalJobMeta: worker.jobMeta,
+          originalWorkerName: worker.queue,
+          error: error
+        }
+        sinon.assert.calledWith(RabbitMQ.prototype.publishEvent, 'worker.errored', erroredJob)
       })
     }) // end _handleWorkerStopError
 

--- a/test/unit/worker.js
+++ b/test/unit/worker.js
@@ -93,6 +93,12 @@ describe('Worker', () => {
       assert.deepEqual(w.errorCat, { mew: 2 })
     })
 
+    it('should use the given errorPublisher', () => {
+      opts.errorPublisher = { mew: 2 }
+      const w = Worker.create(opts)
+      assert.deepEqual(w.errorPublisher, { mew: 2 })
+    })
+
     describe('finalErrorFn', function () {
       it('should use passed for function to resolve', () => {
         opts.finalRetryFn = sinon.stub().rejects(new Error('Glorfindel'))


### PR DESCRIPTION
Add `errorPublisher` that would publish all worker stop errors to the global `error` exchange