### PR TITLE
Add ability to pass queueOptions to queues create on the subscribed exchange

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "mocha": "^3.0.1",
     "sinon": "^1.17.0",
     "sinon-as-promised": "^4.0.0",
-    "standard": "^8.1.0"
+    "standard": "8.1.0"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -322,7 +322,7 @@ class Server {
     .then(() => {
       return Promise.map(events.keySeq(), (exchange) => {
         const worker = events.get(exchange)
-        const options = this._workerOptions[exchange] || {}
+        const options = this._workerOptions[exchange]
         const queueOptions = options.queueOptions
         return this._rabbitmq.subscribeToFanoutExchange(
           exchange,

--- a/src/server.js
+++ b/src/server.js
@@ -321,11 +321,15 @@ class Server {
     })
     .then(() => {
       return Promise.map(events.keySeq(), (exchange) => {
+        const worker = events.get(exchange)
+        const options = this._workerOptions[exchange] || {}
+        const queueOptions = options.queueOptions
         return this._rabbitmq.subscribeToFanoutExchange(
           exchange,
           (job, jobMeta, done) => {
-            this._enqueue(exchange, events.get(exchange), job, jobMeta, done)
-          }
+            this._enqueue(exchange, worker, job, jobMeta, done)
+          },
+          queueOptions
         )
       })
     })

--- a/src/server.js
+++ b/src/server.js
@@ -322,7 +322,7 @@ class Server {
     .then(() => {
       return Promise.map(events.keySeq(), (exchange) => {
         const worker = events.get(exchange)
-        const options = this._workerOptions[exchange]
+        const options = this._workerOptions[exchange] || {}
         const queueOptions = options.queueOptions
         return this._rabbitmq.subscribeToFanoutExchange(
           exchange,


### PR DESCRIPTION
We we subscribe to exchange and create queues there is no way to pass queueOptions right now.
So we can't say `autoDelete: true` or something like that.
This PR fixes this problem.